### PR TITLE
Advanced and Normal Mode for Plugin

### DIFF
--- a/assets/css/aspirepress.css
+++ b/assets/css/aspirepress.css
@@ -2,6 +2,7 @@
     0% {
         background-color: rgba(255, 223, 0, 0.1);
     }
+
     100% {
         background-color: none;
     }
@@ -23,4 +24,8 @@
     flex: 0 1 auto;
     margin: 0 0 10px;
     box-sizing: border-box;
+}
+
+.normal-mode .advanced-setting {
+    display: none !important;
 }


### PR DESCRIPTION
# Pull Request

## What changed?

1) Added Reset Button
2) Added Advanced mode for the plugin UI which can be accessed by added "&advanced=true" to the plugin settings page URL.  This will reveal the full feature set.
3) Defaults to the aspirepress API once activated

## Why did it change?

Advanced and Normal Mode for Plugin to avoid confusing casual users

## Did you fix any specific issues?

(Please tag any specific issues here...)

## CERTIFICATION

By opening this pull request, I do agree to abide by the [CODE OF CONDUCT](CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.

Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity.

Finally, I agree that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code. 

(Please check a box below)

[X] I agree
[ ] I do not agree