### PR TITLE
WP Playground  link in README, added readme.txt for plugin-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AspirePress Update Plugin
+# AspireUpdate
 
 This plugin allows a WordPress user to automatically rewrite certain URLs and URL paths to a new URL. This is
 helpful because it allows for the rewriting of `api.wordpress.org` to some other repository that contains the plugins

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The plugin menu appears under the Dashboard main menu item. Don't look for it in
 
 The plugin can use the following configuration options in wp-config.php:
 
-| Configuration Parameter |                                                                  Description |                        Default, if any |
-| :---------------------- | ---------------------------------------------------------------------------: | -------------------------------------: |
-| AP_ENABLE               |                         The API Key for AspireCloud (not currently enforced) |                                   none |
-| AP_API_KEY              |                                                          Enable API rewrites |                                   true |
-| AP_HOST                 |                                                              API domain name |                    api.aspirecloud.org |
-| AP_DEBUG                |                                                            Enable Debug Mode |                                  false |
-| AP_DEBUG_TYPES          |                                                      an array of debug modes | array('string', 'request', 'response') |
-| AP_DISABLE_SSL          |                                  Disabled SSL verification for local testing |                                   true |
+| Configuration Parameter |                                                                                 Description |                        Default, if any |
+| :---------------------- | ------------------------------------------------------------------------------------------: | -------------------------------------: |
+| AP_ENABLE               |                                                                          Enable API rewrite |                                  false |
+| AP_API_KEY              |                           The API Key for AspireCloud (not currently enforced)            s |                                        |
+| AP_HOST                 |                                                                             API domain name |                    api.aspirecloud.org |
+| AP_DEBUG                |                                                                           Enable Debug Mode |                                  false |
+| AP_DEBUG_TYPES          |                                                                     an array of debug modes | array('string', 'request', 'response') |
+| AP_DISABLE_SSL          |                                                 Disabled SSL verification for local testing |                                   true |
 | AP_REMOVE_UI            | Disables plugin settings user interface, defaults to config parameters set in wp-config.php |                                  false |
 
 To set AP_DEBUG_TYPES use an array to define the constant:
@@ -57,6 +57,8 @@ NOTE: Any AspirePress configuration parameters set in wp-config.php _will_ overr
 
 
 NOTE 2: Setting AP_REMOVE_UI to `true` removes the plugin user interface. This is intended to be used in situations where AspireUpdate is deployed in a pre-configured mode and end-user configuration is not expected nor allowed. 
+
+
 
 
 ## Debug Logging

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ NOTE 2: Setting AP_REMOVE_UI to `true` removes the plugin user interface. This i
 
 ## WP Playgrounds Support
 
-The AspireUpdate plugin can be quickly [experimented with in the WP Playgrounds environment](https://github.com/aspirepress/AspireUpdate/blob/playground-ready/assets/playground/blueprint.json).
+The AspireUpdate plugin can be quickly [experimented with in the WP Playgrounds environment](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/aspirepress/AspireUpdate/refs/heads/playground-ready/assets/playground/blueprint.json).
 
 ## Debug Logging
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ NOTE: Any AspirePress configuration parameters set in wp-config.php _will_ overr
 
 NOTE 2: Setting AP_REMOVE_UI to `true` removes the plugin user interface. This is intended to be used in situations where AspireUpdate is deployed in a pre-configured mode and end-user configuration is not expected nor allowed. 
 
+## WP Playgrounds Support
 
-
+The AspireUpdate plugin can be quickly [experimented with in the WP Playgrounds environment](https://github.com/aspirepress/AspireUpdate/blob/playground-ready/assets/playground/blueprint.json).
 
 ## Debug Logging
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The plugin can use the following configuration options in wp-config.php:
 | Configuration Parameter |                                                                                 Description |                        Default, if any |
 | :---------------------- | ------------------------------------------------------------------------------------------: | -------------------------------------: |
 | AP_ENABLE               |                                                                          Enable API rewrite |                                  false |
-| AP_API_KEY              |                           The API Key for AspireCloud (not currently enforced)            s |                                        |
+| AP_API_KEY              |                                        The API Key for AspireCloud (not currently enforced) |                                        |
 | AP_HOST                 |                                                                             API domain name |                    api.aspirecloud.org |
 | AP_DEBUG                |                                                                           Enable Debug Mode |                                  false |
 | AP_DEBUG_TYPES          |                                                                     an array of debug modes | array('string', 'request', 'response') |

--- a/assets/playground/blueprint.json
+++ b/assets/playground/blueprint.json
@@ -25,7 +25,7 @@
         "networking": true
     },
     "login": true,
-    "landingPage": "/wp-admin/admin.php?page=aspirepress-settings",
+    "landingPage": "/wp-admin/admin.php?page=aspireupdate-settings",
     "steps": [
         {
             "step": "defineWpConfigConsts",

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,41 @@
+=== Plugin Name ===
+Contributors: sarah-savage, namithj, asirota
+Donate link: https://github.com/sponsors/aspirepress
+Tags: 
+Requires at least: 5.3
+Tested up to: 6.7
+Stable tag: 0.5
+Requires PHP: 7.4
+License: GPL-3.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
+
+This plugin allows a WordPress user to automatically rewrite certain URLs and URL paths to a new URL.
+
+== Description ==
+
+This plugin allows a WordPress user to automatically rewrite certain URLs and URL paths to a new URL. This is helpful because it allows for the rewriting of api.wordpress.org to some other repository that contains the plugins the user wants.
+
+The plugin supports multiple rewrites, and also supports rewriting the URL paths of the requests on a per-host basis. This improves the capacity of the plugin to adequately support newer or different repositories.
+.
+
+== Frequently Asked Questions ==
+
+= A question that someone might have =
+
+An answer to that question.
+
+= What about foo bar? =
+
+Answer to foo bar dilemma.
+
+== Screenshots ==
+
+1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Screenshots are stored in the /assets directory.
+2. This is the second screen shot
+
+== Changelog ==
+
+= 0.5 =
+* first stable version, connects to api.wordpress.org or an alternative AspireCloud repository
+
+== Upgrade Notice ==


### PR DESCRIPTION
# Pull Request

## What changed?

add WP Playground link in readme

## Why did it change?

playground-ready branch contains the currently stable version to be experimented with on docs.aspirepress.org

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.