### PR TITLE
Swap descriptions and defaults for `AP_ENABLE` and `AP_API_KEY`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The plugin can use the following configuration options in wp-config.php:
 
 | Configuration Parameter |                                                                  Description |                        Default, if any |
 | :---------------------- | ---------------------------------------------------------------------------: | -------------------------------------: |
-| AP_ENABLE               |                         The API Key for AspireCloud (not currently enforced) |                                   none |
-| AP_API_KEY              |                                                          Enable API rewrites |                                   true |
+| AP_ENABLE               |                                                          Enable API rewrites |                                   true |
+| AP_API_KEY              |                         The API Key for AspireCloud (not currently enforced) |                                   none |
 | AP_HOST                 |                                                              API domain name |                    api.aspirecloud.org |
 | AP_DEBUG                |                                                            Enable Debug Mode |                                  false |
 | AP_DEBUG_TYPES          |                                                      an array of debug modes | array('string', 'request', 'response') |


### PR DESCRIPTION
# Pull Request

## What changed?

I swapped the descriptions and defaults for `AP_ENABLE` and `AP_API_KEY`.

## Why did it change?

They were in the wrong order.

## Did you fix any specific issues

fixes #50 - The incorrect order of descriptions and defaults.

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.