### PR TITLE
Adjust spacing around colon in rewrite debug messages.

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -64,10 +64,10 @@ class API_Rewrite {
 			( '' !== $this->redirected_host )
 		) {
 			if ( false !== strpos( $url, $this->default_host ) ) {
-				Debug::log_string( 'Default API Found :' . $url );
+				Debug::log_string( 'Default API Found: ' . $url );
 				Debug::log_request( $parsed_args );
 				$updated_url = str_replace( $this->default_host, $this->redirected_host, $url );
-				Debug::log_string( 'API Rerouted to :' . $updated_url );
+				Debug::log_string( 'API Rerouted to: ' . $updated_url );
 				if ( true === $this->disable_ssl ) {
 					Debug::log_string( 'SSL Verification Disabled' );
 					$parsed_args['sslverify'] = false;


### PR DESCRIPTION
# Pull Request

## What changed?

A space was removed before the colon `:`, and one added after it.

## Why did it change?

The colon `:` is part of the message, but was displaying as part of the URL.

## Did you fix any specific issues?

fixes #52 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.