### PR TITLE
Update README.md - removing a space from the example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To set AP_DEBUG_TYPES use an array to define the constant:
 
 ```php
 // Works as of PHP 7
-define('AP_DEBUG_TYPES ', array(
+define('AP_DEBUG_TYPES', array(
     'string', 'request', 'response'
 ));
 ```


### PR DESCRIPTION
Removing a space from the:

```php
// Works as of PHP 7
define('AP_DEBUG_TYPES ', array(
    'string', 'request', 'response'
));
```

# Pull Request

## What changed?

Removing a space from the example code of AP_DEBUG_TYPES

## Why did it change?

As its a example it should be correct so its works directly to copy it.

## Did you fix any specific issues?

(https://github.com/aspirepress/AspireUpdate/issues/54)

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.