### PR TITLE
`Add New Plugin`: Remove 'Featured' and 'Favorites' tabs when API rewrite is enabled.

### DIFF
--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -16,6 +16,7 @@ class Controller {
 	 */
 	public function __construct() {
 		Admin_Settings::get_instance();
+		Plugins_Screens::get_instance();
 		$this->api_rewrite();
 	}
 

--- a/includes/class-plugins-screens.php
+++ b/includes/class-plugins-screens.php
@@ -19,9 +19,23 @@ class Plugins_Screens {
 	private static $instance = null;
 
 	/**
+	 * Hold an array of unsupported filters.
+	 *
+	 * @var array
+	 */
+	protected $unsupported_filters = array(
+		'featured',
+		'favorites',
+	);
+
+	/**
 	 * The Constructor.
 	 */
 	public function __construct() {
+		$admin_settings = Admin_Settings::get_instance();
+		if ( $admin_settings->get_setting( 'enable', false ) ) {
+			add_filter( 'install_plugins_tabs', array( $this, 'remove_unused_filter_tabs' ) );
+		}
 	}
 
 	/**
@@ -34,5 +48,18 @@ class Plugins_Screens {
 			self::$instance = new self();
 		}
 		return self::$instance;
+	}
+
+	/**
+	 * Remove unused filter tabs from the Add New Plugin screen.
+	 *
+	 * @param array $tabs An array of tab labels, keyed on each tab's slug.
+	 * @return array An array of tabs.
+	 */
+	public function remove_unused_filter_tabs( $tabs ) {
+		foreach ( $this->unsupported_filters as $filter ) {
+			unset( $tabs[ $filter ] );
+		}
+		return $tabs;
 	}
 }

--- a/includes/class-plugins-screens.php
+++ b/includes/class-plugins-screens.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * The Class for overriding the default plugins screens.
+ *
+ * @package aspire-update
+ */
+
+namespace AspireUpdate;
+
+/**
+ * The Class for overriding the default plugins screens.
+ */
+class Plugins_Screens {
+	/**
+	 * Hold a single instance of the class.
+	 *
+	 * @var object
+	 */
+	private static $instance = null;
+
+	/**
+	 * The Constructor.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Initialize Class.
+	 *
+	 * @return object
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+}


### PR DESCRIPTION
# Pull Request

## What changed?

- Added a new class: `\\AspireUpdate\Plugins_Screens`.
- Added conditional removal of 'Featured' and 'Favorites' tabs when API rewrite is enabled.

## Why did it change?

These tabs are not served by the rewritten API.

## Did you fix any specific issues?

fixes #74 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.