### PR TITLE
`Plugins Screens`: Initialize in `Controller::__construct()`.

### DIFF
--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -16,6 +16,7 @@ class Controller {
 	 */
 	public function __construct() {
 		Admin_Settings::get_instance();
+		Plugins_Screens::get_instance();
 		Themes_Screens::get_instance();
 
 		$this->api_rewrite();


### PR DESCRIPTION
# Pull Request

## What changed?

- Initialize `Plugins Screens` in `Controller::__construct()`.

## Why did it change?

The initialization was added in [94e732e](https://github.com/aspirepress/AspireUpdate/commit/94e732ec1d5556b45344f62c36105afbaf260207), but was accidentally removed when merging [7336a51](https://github.com/aspirepress/AspireUpdate/commit/7336a51d490ac8dad594855026ef2279f9241805).

## Did you fix any specific issues?

Fixes #88 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.