### PR TITLE
`Tests`: Ensure options are not set when tests run.

### DIFF
--- a/aspire-update.php
+++ b/aspire-update.php
@@ -32,4 +32,6 @@ if ( ! defined( 'AP_VERSION' ) ) {
 
 require_once __DIR__ . '/includes/autoload.php';
 
-new AspireUpdate\Controller();
+if ( ! defined( 'AP_RUN_TESTS' ) ) {
+	new AspireUpdate\Controller();
+}

--- a/tests/AdminSettings/AdminSettings_GetSettingTest.php
+++ b/tests/AdminSettings/AdminSettings_GetSettingTest.php
@@ -12,28 +12,15 @@
  */
 class AdminSettings_GetSettingTest extends WP_UnitTestCase {
 	/**
-	 * Shared instance of the class.
-	 *
-	 * @var \AspireUpdate\Admin_Settings
-	 */
-	private static $instance;
-
-	/**
-	 * Set up before any tests run.
-	 */
-	public static function set_up_before_class() {
-		self::$instance = \AspireUpdate\Admin_Settings::get_instance();
-	}
-
-	/**
 	 * Test that the default 'api_host' value is retrieved.
 	 * 
 	 * @covers \AspireUpdate\Admin_Settings::get_default_settings
 	 */
 	public function test_should_get_default_api_host() {
-		$actual = self::$instance->get_setting( 'api_host' );
+		$admin_settings = new \AspireUpdate\Admin_Settings();
+		$actual         = $admin_settings->get_setting( 'api_host' );
 
 		$this->assertIsString( $actual, 'The API host value is not a string.' );
-		$this->assertNotEmpty( $actual, 'The API host value is empty. ' . var_export( $actual, true ) );
+		$this->assertNotEmpty( $actual, 'The API host value is empty. ' );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,8 @@
  * @package AspireUpdate
  */
 
+define( 'AP_RUN_TESTS', true );
+
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {


### PR DESCRIPTION
# Pull Request

## What changed?

1. The instantiation of `\AspireUpdate\Controller` is guarded so that it doesn't run when the tests are running.
2. A new object is used for each test so that state doesn't spill into other tests.

## Why did it change?

`\AspireUpdate\Controller` was instantiated in the main plugin file.
This affected test runs because options were already set.

## Did you fix any specific issues?

Fixes #94 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.