### PR TITLE
`Tests`: Add default coverage settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /phpunit.xml
 /vendor
 .cache/*
+/tests/cache
+/tests/coverage

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,17 @@
 			<directory suffix="Test.php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+	<coverage includeUncoveredFiles="true" processUncoveredFiles="false" pathCoverage="true" cacheDirectory="./tests/cache">
+		<include>
+			<file>./aspire-update.php</file>
+			<directory suffix=".php">./includes</directory>
+		</include>
+		<exclude>
+			<file>./includes/autoload.php</file>
+		</exclude>
+		<report>
+			<text outputFile="php://stdout" showOnlySummary="true"/>
+			<html outputDirectory="./tests/coverage"/>
+		</report>
+	</coverage>
 </phpunit>


### PR DESCRIPTION
# Pull Request

## What changed?

- A `<coverage>` element was added to `phpunit.xml.dist`.
- The coverage directory defaults to `/tests/coverage`.
- The test cache directory defaults to `/tests/cache`.
- The `/tests/coverage` and `/tests/cache` directories have been added to `.gitignore`.
- Only the main plugin file and "code-only" files in the `includes` directory are included in coverage reports.
- `includes/autoload.php` is excluded from coverage reports.

## Why did it change?

Running coverage reports can be cumbersome for experienced and inexperienced users.

This makes it much more convenient to run a coverage report when writing tests to ensure the tests are covering the expected portions of code.

## Did you fix any specific issues?

Fixes #96 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.