### PR TITLE
Warning when debug-aspire-update.log doesnt exist

### DIFF
--- a/includes/class-debug.php
+++ b/includes/class-debug.php
@@ -71,20 +71,16 @@ class Debug {
 
 		$file_path = WP_CONTENT_DIR . '/' . self::$log_file;
 
-		$content = $wp_filesystem->get_contents( $file_path );
-		if ( false === $content ) {
-			$wp_filesystem->put_contents(
-				$file_path,
-				$formatted_message,
-				FS_CHMOD_FILE
-			);
-		} else {
-			$wp_filesystem->put_contents(
-				$file_path,
-				$content . $formatted_message,
-				FS_CHMOD_FILE
-			);
+		$content = '';
+		if ( $wp_filesystem->exists( $file_path ) ) {
+			$content = $wp_filesystem->get_contents( $file_path );
 		}
+
+		$wp_filesystem->put_contents(
+			$file_path,
+			$content . $formatted_message,
+			FS_CHMOD_FILE
+		);
 	}
 
 	/**


### PR DESCRIPTION
# Pull Request

## What changed?

Fixes Warning when debug-aspire-update.log doesnt exist

## Why did it change?

Fixes Warning when debug-aspire-update.log doesnt exist

## Did you fix any specific issues?

Fixes #57

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.