### PR TITLE
`Admin Settings`: Delete all settings when the plugin is uninstalled.

### DIFF
--- a/aspire-update.php
+++ b/aspire-update.php
@@ -46,3 +46,13 @@ function aspire_update() {
 		new AspireUpdate\Controller();
 	}
 }
+
+register_activation_hook( __FILE__, 'aspire_update_activation_hook' );
+function aspire_update_activation_hook() {
+	register_uninstall_hook( __FILE__, 'aspire_update_uninstall_hook' );
+}
+
+function aspire_update_uninstall_hook() {
+	$admin_settings = AspireUpdate\Admin_Settings::get_instance();
+	$admin_settings->delete_all_settings();
+}

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -104,6 +104,15 @@ class Admin_Settings {
 	}
 
 	/**
+	 * Delete all settings.
+	 *
+	 * @return void
+	 */
+	public function delete_all_settings() {
+		delete_site_option( $this->option_name );
+	}
+
+	/**
 	 * The Admin Notice to convey a Reset Operation has happened.
 	 *
 	 * @return void


### PR DESCRIPTION
# Pull Request

## What changed?

- `\AspireUpdate\Admin_Settings` has a new method: `::delete_all_settings()`. This method is multisite-safe.
- `aspire-update.php`:
  - Registers an activation hook which performs a once-per-activation registration of an uninstall hook.
    - The activation hook is used to avoid registering the same uninstall hook on every load.
    - The uninstall hook calls the new `\AspireUpdate\Admin_Settings::delete_all_settings()` method when the plugin is uninstalled.

## Why did it change?

Settings were persisting in the database after the plugin was uninstalled. We should clean up after ourselves.

## Did you fix any specific issues?

Fixes #101

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.