### PR TITLE
create zip with each new tagged release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 .editorconfig export-ignore
 composer.lock export-ignore
 phpunit.xml export-ignore
+phpunit.xml.dist export-ignore
 phpcs.xml export-ignore
 phpcs.xml.dist export-ignore
 .phpcs.xml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.editorconfig export-ignore
+composer.lock export-ignore
+phpunit.xml export-ignore
+phpcs.xml export-ignore
+phpcs.xml.dist export-ignore
+.phpcs.xml export-ignore
+/.github export-ignore
+/bin export-ignore
+/tests export-ignore

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    tags:
+      - "**"
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Get tag
+        id: tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Build project
+        run: git archive -o /tmp/AspireUpdate-${{ steps.tag.outputs.tag }}.zip --prefix=AspireUpdate/ ${{ steps.tag.outputs.tag }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          release_name: ${{ steps.tag.outputs.tag }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /tmp/AspireUpdate-${{ steps.tag.outputs.tag }}.zip
+          asset_name: AspireUpdate-${{ steps.tag.outputs.tag }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
# Pull Request

## What changed?

Added `.gitattributes` file to ignore specific files during a zip download.
Added a GitHub Action to create a zip file release asset with each new tagged release.

This is the same process I've been using with Git Updater for a while now.
https://github.com/afragen/git-updater/releases/tag/12.6.0

## Why did it change?

Fixes #120 

## Did you fix any specific issues?

Nothing broken, just better.

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.