### PR TITLE
#128 Make the API Key Error Translatable

### DIFF
--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -150,7 +150,7 @@ class ApiRewrites {
 					if ((response.status === 400) || (response.status === 401)) {
 						ApiRewrites.api_key.show_error(response.responseJSON?.error);
 					} else {
-						ApiRewrites.api_key.show_error('Unexpected Error: ' + response.status);
+						ApiRewrites.api_key.show_error(aspireupdate.string_unexpected_error + ' ' + response.status);
 					}
 				});
 		},

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -53,7 +53,6 @@ class Admin_Settings {
 
 		add_action( 'admin_init', [ $this, 'update_settings' ] );
 		add_action( 'network_admin_edit_aspireupdate-settings', [ $this, 'update_settings' ] );
-
 	}
 
 	/**
@@ -102,7 +101,6 @@ class Admin_Settings {
 						'reset-success-nonce' => wp_create_nonce( 'aspireupdate-reset-success-nonce' ),
 
 					],
-
 					network_admin_url( 'index.php?page=aspireupdate-settings' )
 				)
 			);
@@ -245,9 +243,7 @@ class Admin_Settings {
 			update_site_option( $this->option_name, $this->sanitize_settings( wp_unslash( $_POST['aspireupdate_settings'] ) ) );
 
 			wp_safe_redirect(
-
 				add_query_arg( [ network_admin_url( 'index.php?page=aspireupdate-settings' ) ] )
-
 			);
 			exit;
 		}
@@ -291,12 +287,11 @@ class Admin_Settings {
 		wp_localize_script(
 			'aspire_update_settings_js',
 			'aspireupdate',
-
 			[
-
-				'ajax_url' => network_admin_url( 'admin-ajax.php' ),
-				'nonce'    => wp_create_nonce( 'aspireupdate-ajax' ),
-				'domain'   => Utilities::get_top_level_domain(),
+				'ajax_url'                => network_admin_url( 'admin-ajax.php' ),
+				'nonce'                   => wp_create_nonce( 'aspireupdate-ajax' ),
+				'domain'                  => Utilities::get_top_level_domain(),
+				'string_unexpected_error' => esc_html__( 'Unexpected Error:', 'AspireUpdate' ),
 			]
 		);
 	}
@@ -313,7 +308,6 @@ class Admin_Settings {
 				'reset-nonce' => wp_create_nonce( 'aspireupdate-reset-nonce' ),
 
 			],
-
 			network_admin_url( 'index.php?page=aspireupdate-settings' )
 		);
 		?>

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -20,9 +20,7 @@ class Controller {
 		Themes_Screens::get_instance();
 		$this->api_rewrite();
 
-
 		add_action( 'init', [ $this, 'load_textdomain' ] );
-
 	}
 
 	/**
@@ -57,5 +55,4 @@ class Controller {
 	public function load_textdomain() {
 		\load_plugin_textdomain( 'AspireUpdate', false, AP_PATH . '/languages/' );
 	}
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,7 +33,6 @@ require_once "{$_tests_dir}/includes/functions.php";
 function _manually_load_plugin() {
 
 	require dirname( __DIR__ ) . '/aspire-update.php';
-
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );


### PR DESCRIPTION
# Pull Request

## What changed?

1) #128 Make the API Key Error Translatable
2) Coding Standards auto update, this should stop once one of the newer PRs are merged.

## Why did it change?

Make the API Key Error Message Prefix Translatable

## Did you fix any specific issues?

#128 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.