### PR TITLE
Resolve PCP security warnings in `AspireUpdate\Admin_Settings::update_settings()`.

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -239,8 +239,7 @@ class Admin_Settings {
 		}
 
 		// Save settings and redirect.
-		if ( ( isset( $_POST['option_page'] ) && 'aspireupdate_settings' === $_POST['option_page'] ) ) {
-			update_site_option( $this->option_name, $this->sanitize_settings( wp_unslash( $_POST['aspireupdate_settings'] ) ) );
+		if ( ( isset( $_POST['option_page'], $_POST['aspireupdate_settings'] ) && 'aspireupdate_settings' === $_POST['option_page'] ) ) {
 
 			wp_safe_redirect(
 				add_query_arg( [ network_admin_url( 'index.php?page=aspireupdate-settings' ) ] )

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -240,6 +240,11 @@ class Admin_Settings {
 
 		// Save settings and redirect.
 		if ( ( isset( $_POST['option_page'], $_POST['aspireupdate_settings'] ) && 'aspireupdate_settings' === $_POST['option_page'] ) ) {
+			update_site_option(
+				$this->option_name,
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Contents are sanitized in Admin_Settings::sanitize_settings.
+				$this->sanitize_settings( wp_unslash( $_POST['aspireupdate_settings'] ) )
+			);
 
 			wp_safe_redirect(
 				add_query_arg( [ network_admin_url( 'index.php?page=aspireupdate-settings' ) ] )


### PR DESCRIPTION
# Pull Request

## What changed?

1. A check was added to ensure `$_POST['aspireupdate_settings']` is set.
2. A `// phpcs:ignore <sniff> -- <explanation>` comment was added.
    - The contents of `$_POST['aspireupdate_settings']` are sanitized in `AspireUpdate\Admin_Settings::sanitize_settings()`.
    - **Such comments should be used extremely rarely.**
      - While we could add a `rule.properties.property.element` entry to `phpcs.xml.dist` to denote this as a custom sanitizing function, it appears that PCP doesn't take this into consideration. Therefore, an ignore comment seems appropriate here.

## Why did it change?

PCP was showing warnings from the "Plugin Repo" checks.

## Did you fix any specific issues?

Fixes #132 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.