### PR TITLE
rename from AspireUpdate to aspire-update

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build project
-        run: git archive -o /tmp/AspireUpdate-${{ steps.tag.outputs.tag }}.zip --prefix=AspireUpdate/ ${{ steps.tag.outputs.tag }}
+        run: git archive -o /tmp/aspire-update-${{ steps.tag.outputs.tag }}.zip --prefix=aspire-update/ ${{ steps.tag.outputs.tag }}
 
       - name: Create Release
         id: create_release
@@ -38,6 +38,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/AspireUpdate-${{ steps.tag.outputs.tag }}.zip
-          asset_name: AspireUpdate-${{ steps.tag.outputs.tag }}.zip
+          asset_path: /tmp/aspire-update-${{ steps.tag.outputs.tag }}.zip
+          asset_name: aspire-update-${{ steps.tag.outputs.tag }}.zip
           asset_content_type: application/zip


### PR DESCRIPTION
# Pull Request

Rename zip from AspireUpdate to aspire-update. Better conforms to dot org naming guidelines.

Related #120 

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.