### PR TITLE
Workflows: Update Playground blueprint with repo and branch/tag names.

### DIFF
--- a/.github/workflows/playground-blueprint.yml
+++ b/.github/workflows/playground-blueprint.yml
@@ -1,0 +1,44 @@
+name: Update Blueprint Blueprint with Repository and Branch
+
+on:
+  push:
+    branches:
+      - main
+      - playground-ready
+    tags:
+      - "**"
+
+jobs:
+  update-blueprint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set Branch or Tag Name
+        id: branch-name
+        run: |
+          if [ "${{ github.ref_type }}" == "branch" ]; then
+            echo "CURRENT_REF=${{ github.ref_name }}" >> $GITHUB_ENV
+          elif [ "${{ github.ref_type }}" == "tag" ]; then
+            echo "CURRENT_REF=${{ github.ref_name }}" >> $GITHUB_ENV
+          fi
+
+      - name: Update Blueprint JSON
+        run: |
+          jq --tab '.plugins[0] |= "https://github-proxy.com/proxy/?repo='$GITHUB_REPOSITORY'&branch='$CURRENT_REF'"' assets/playground/blueprint.json > assets/playground/blueprint.json.tmp
+          mv assets/playground/blueprint.json.tmp assets/playground/blueprint.json
+
+      - name: Commit and Push Changes
+        run: |
+          if git diff --cached --quiet; then
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add assets/playground/blueprint.json
+            git commit -m "Update blueprint.json for branch/tag ${{ env.name }}"
+            git push
+          fi
+        env:
+          name: ${{ env.name }}
+


### PR DESCRIPTION
# Pull Request

## What changed?

- A new workflow has been added which will update the Playground blueprint with the current repository and branch/tag names.
    - Handling the repository name means that even renaming the repository will be covered for each branch on their next push.
    - A commit is only attempted if the workflow made a change.
    - Uses the same `tags` entry as the `releases.yml` workflow for consistency.

## Why did it change?

Playground testing is currently only possible on the `playground-ready` branch. By updating the playground blueprint for the `main` branch and tags, these can be tested too.

## Did you fix any specific issues?

Fixes #141 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the ersion in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.

Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree that this code may be licensed under any license deemed appropriate by AspirePress, including but not limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my rights or my copyright to this code.
