### PR TITLE
Workflows: Add write permission for playground blueprint

### DIFF
--- a/.github/workflows/playground-blueprint.yml
+++ b/.github/workflows/playground-blueprint.yml
@@ -1,4 +1,4 @@
-name: Update Blueprint Blueprint with Repository and Branch
+name: Update Playground Blueprint with Repository and Branch
 
 on:
   push:

--- a/.github/workflows/playground-blueprint.yml
+++ b/.github/workflows/playground-blueprint.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   update-blueprint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Pull Request

## What changed?

- The `write` permission has now been added to the Playground blueprint workflow.

## Why did it change?

githubactions[bot] didn't have sufficient permission to perform the required actions.

## Did you fix any specific issues?

Fixes #141 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the ersion in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.

Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree that this code may be licensed under any license deemed appropriate by AspirePress, including but not limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my rights or my copyright to this code.
