### PR TITLE
Have Playground blueprint default to `main`.

### DIFF
--- a/.github/workflows/playground-blueprint.yml
+++ b/.github/workflows/playground-blueprint.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update-blueprint:
+    if: github.repository == 'aspirepress/AspireUpdate'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/playground-blueprint.yml
+++ b/.github/workflows/playground-blueprint.yml
@@ -3,7 +3,6 @@ name: Update Blueprint Blueprint with Repository and Branch
 on:
   push:
     branches:
-      - main
       - playground-ready
     tags:
       - "**"

--- a/assets/playground/blueprint.json
+++ b/assets/playground/blueprint.json
@@ -17,7 +17,7 @@
 		"blogname": "AspireUpdate Demo Site"
 	},
 	"plugins": [
-		"https://github-proxy.com/proxy/?repo=AspirePress/AspireUpdate&branch=playground-ready",
+		"https://github-proxy.com/proxy/?repo=AspirePress/AspireUpdate&branch=main",
 		"error-log-viewer",
 		"plugin-check"
 	],


### PR DESCRIPTION
# Pull Request

## What changed?

- The workflow now only runs on the `aspirepress/AspireUpdate` repository.
- `main` has been removed from the applicable branches for the Playground blueprint workflow.
- The WordPress Playground `blueprint.json` defaults to the `main` branch now, rather than the `playground-ready` branch.

## Why did it change?

Previously, upon a `push` event to the `main` branch, the Playground blueprint workflow would make a follow-up commit to make the playground branch URL match `main`.

However, the `main` branch is a *protected* branch. This means changes can only be made by Pull Request. Therefore, the workflow cannot make a direct commit.

Since `main` is the only *protected* branch, this should be the default for the Playground blueprint.

Additionally, the workflow ran on the main repository _and_ on forks, creating an instant merge conflict when the `main` branch of a fork was synced.

## Did you fix any specific issues?

Fixes #141 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the ersion in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.

Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree that this code may be licensed under any license deemed appropriate by AspirePress, including but not limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my rights or my copyright to this code.
