### PR TITLE
update afragen/translations-updater with error caching/logging

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -53,12 +53,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/translations-updater.git",
-                "reference": "d7a54f15ffd0a047c42e4d095a77d9676a726062"
+                "reference": "72808f439327ba84e8194ed80141fec3bbd0b1b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/d7a54f15ffd0a047c42e4d095a77d9676a726062",
-                "reference": "d7a54f15ffd0a047c42e4d095a77d9676a726062",
+                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/72808f439327ba84e8194ed80141fec3bbd0b1b8",
+                "reference": "72808f439327ba84e8194ed80141fec3bbd0b1b8",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/afragen/translations-updater/issues",
                 "source": "https://github.com/afragen/translations-updater"
             },
-            "time": "2024-11-18T02:10:24+00:00"
+            "time": "2024-11-18T19:47:01+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -49,16 +49,16 @@
         },
         {
             "name": "afragen/translations-updater",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/translations-updater.git",
-                "reference": "0bde072a1bf92ddc43837f6a27b9475b651350ea"
+                "reference": "583eafb6c884eb5b1f39e95f9b707c200dd303ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/0bde072a1bf92ddc43837f6a27b9475b651350ea",
-                "reference": "0bde072a1bf92ddc43837f6a27b9475b651350ea",
+                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/583eafb6c884eb5b1f39e95f9b707c200dd303ac",
+                "reference": "583eafb6c884eb5b1f39e95f9b707c200dd303ac",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/afragen/translations-updater/issues",
                 "source": "https://github.com/afragen/translations-updater"
             },
-            "time": "2024-11-13T00:36:43+00:00"
+            "time": "2024-11-16T22:14:55+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -53,12 +53,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/translations-updater.git",
-                "reference": "a75dab9f087943ef239080959662a0988060032b"
+                "reference": "d7a54f15ffd0a047c42e4d095a77d9676a726062"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/a75dab9f087943ef239080959662a0988060032b",
-                "reference": "a75dab9f087943ef239080959662a0988060032b",
+                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/d7a54f15ffd0a047c42e4d095a77d9676a726062",
+                "reference": "d7a54f15ffd0a047c42e4d095a77d9676a726062",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/afragen/translations-updater/issues",
                 "source": "https://github.com/afragen/translations-updater"
             },
-            "time": "2024-11-18T01:28:26+00:00"
+            "time": "2024-11-18T02:10:24+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -53,12 +53,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/translations-updater.git",
-                "reference": "583eafb6c884eb5b1f39e95f9b707c200dd303ac"
+                "reference": "4179c8ade255f1456ac224fef668b03befa7e389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/583eafb6c884eb5b1f39e95f9b707c200dd303ac",
-                "reference": "583eafb6c884eb5b1f39e95f9b707c200dd303ac",
+                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/4179c8ade255f1456ac224fef668b03befa7e389",
+                "reference": "4179c8ade255f1456ac224fef668b03befa7e389",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/afragen/translations-updater/issues",
                 "source": "https://github.com/afragen/translations-updater"
             },
-            "time": "2024-11-16T22:14:55+00:00"
+            "time": "2024-11-16T23:45:14+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -49,16 +49,16 @@
         },
         {
             "name": "afragen/translations-updater",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/translations-updater.git",
-                "reference": "4179c8ade255f1456ac224fef668b03befa7e389"
+                "reference": "bb5bc4c5476a9234244b8f2bdf8af5dd3a9671ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/4179c8ade255f1456ac224fef668b03befa7e389",
-                "reference": "4179c8ade255f1456ac224fef668b03befa7e389",
+                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/bb5bc4c5476a9234244b8f2bdf8af5dd3a9671ab",
+                "reference": "bb5bc4c5476a9234244b8f2bdf8af5dd3a9671ab",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/afragen/translations-updater/issues",
                 "source": "https://github.com/afragen/translations-updater"
             },
-            "time": "2024-11-16T23:45:14+00:00"
+            "time": "2024-11-17T23:35:37+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -53,12 +53,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/translations-updater.git",
-                "reference": "72808f439327ba84e8194ed80141fec3bbd0b1b8"
+                "reference": "c688e85eeef136f9cd7a4719db94ab0fc241601e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/72808f439327ba84e8194ed80141fec3bbd0b1b8",
-                "reference": "72808f439327ba84e8194ed80141fec3bbd0b1b8",
+                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/c688e85eeef136f9cd7a4719db94ab0fc241601e",
+                "reference": "c688e85eeef136f9cd7a4719db94ab0fc241601e",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/afragen/translations-updater/issues",
                 "source": "https://github.com/afragen/translations-updater"
             },
-            "time": "2024-11-18T19:47:01+00:00"
+            "time": "2024-11-19T17:24:59+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -53,12 +53,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/translations-updater.git",
-                "reference": "bb5bc4c5476a9234244b8f2bdf8af5dd3a9671ab"
+                "reference": "a75dab9f087943ef239080959662a0988060032b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/bb5bc4c5476a9234244b8f2bdf8af5dd3a9671ab",
-                "reference": "bb5bc4c5476a9234244b8f2bdf8af5dd3a9671ab",
+                "url": "https://api.github.com/repos/afragen/translations-updater/zipball/a75dab9f087943ef239080959662a0988060032b",
+                "reference": "a75dab9f087943ef239080959662a0988060032b",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 "issues": "https://github.com/afragen/translations-updater/issues",
                 "source": "https://github.com/afragen/translations-updater"
             },
-            "time": "2024-11-17T23:35:37+00:00"
+            "time": "2024-11-18T01:28:26+00:00"
         }
     ],
     "packages-dev": [

--- a/vendor/afragen/translations-updater/CHANGES.md
+++ b/vendor/afragen/translations-updater/CHANGES.md
@@ -1,8 +1,9 @@
 #### [unreleased]
 
-#### 1.2.0 / 2024-11-17
+#### 1.2.0 / 2024-11-19
 * return `WP_Error` in `Language_Pack_API::get_language_pack()` with validation error
 * exit gracefully if `Language_Pack_API::get_language_pack()` returns `WP_Error`
+* updated error logging for GitHub API rate limits
 
 ####  1.1.0 / 2024-11-16
 * add API error caching/logging

--- a/vendor/afragen/translations-updater/CHANGES.md
+++ b/vendor/afragen/translations-updater/CHANGES.md
@@ -1,5 +1,8 @@
 #### [unreleased]
 
+####  1.1.0 / 2024-11-16
+* add API error caching/logging
+
 #### 1.0.1 / 2024-11-12
 * fixed a hard-coded 'master' branch in `Language_Pack_API::process_language_pack_package()`
 

--- a/vendor/afragen/translations-updater/CHANGES.md
+++ b/vendor/afragen/translations-updater/CHANGES.md
@@ -1,5 +1,9 @@
 #### [unreleased]
 
+#### 1.2.0 / 2024-11-17
+* return `WP_Error` in `Language_Pack_API::get_language_pack()` with validation error
+* exit gracefully if `Language_Pack_API::get_language_pack()` returns `WP_Error`
+
 ####  1.1.0 / 2024-11-16
 * add API error caching/logging
 * always return `$this->repo` in `Language_Pack_API::get_language_pack()`

--- a/vendor/afragen/translations-updater/CHANGES.md
+++ b/vendor/afragen/translations-updater/CHANGES.md
@@ -2,6 +2,7 @@
 
 ####  1.1.0 / 2024-11-16
 * add API error caching/logging
+* always return `$this->repo` in `Language_Pack_API::get_language_pack()`
 
 #### 1.0.1 / 2024-11-12
 * fixed a hard-coded 'master' branch in `Language_Pack_API::process_language_pack_package()`

--- a/vendor/afragen/translations-updater/README.md
+++ b/vendor/afragen/translations-updater/README.md
@@ -13,11 +13,11 @@
 
 This framework allows for decoupled language pack updates for your WordPress plugins or themes that are hosted on public repositories in GitHub, Bitbucket, GitLab, or Gitea.
 
- The URI should point to a repository that contains the translations files. Refer to [GitHub Updater Translations](https://github.com/afragen/github-updater-translations) as an example. It is created using the [Language Pack Maker](https://github.com/afragen/language-pack-maker). The repo **must** be a public repo.
+ The URI should point to a repository that contains the translations files. Refer to [Git Updater Translations](https://github.com/afragen/git-updater-translations) as an example. It is created using the [Language Pack Maker](https://github.com/afragen/language-pack-maker). The repo **must** be a public repo.
 
 ## Usage
 
-Install via Composer: `composer require afragen/translations-updater:dev-master`
+Install via Composer: `composer require afragen/translations-updater:^1`
 
 **Prior to release use the following command**
 `composer require afragen/translations-updater:dev-<branch>` currently `dev-master`
@@ -34,7 +34,7 @@ add_action( 'admin_init', function() {
 		'slug'      => 'my-repo-slug', // Should be lowercase.
 		'version'   => 'my-repo-version', // Current version of plugin|theme.
 		'languages' => 'https://my-path-to/language-packs',
-		'branch'    => 'master', // Default.
+		'branch'    => 'master', // Default (optional).
 	];
 
 	( new \Fragen\Translations_Updater\Init() )->run( $config );

--- a/vendor/afragen/translations-updater/composer.json
+++ b/vendor/afragen/translations-updater/composer.json
@@ -3,7 +3,7 @@
   "description": "This framework provides automatic decoupled languate pack updates from a public repository for your WordPress plugin or theme.",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "keywords": [
     "wordpress",
     "plugin",

--- a/vendor/afragen/translations-updater/composer.json
+++ b/vendor/afragen/translations-updater/composer.json
@@ -3,7 +3,7 @@
   "description": "This framework provides automatic decoupled languate pack updates from a public repository for your WordPress plugin or theme.",
   "type": "library",
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "keywords": [
     "wordpress",
     "plugin",

--- a/vendor/afragen/translations-updater/src/Translations_Updater/API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/API.php
@@ -115,7 +115,7 @@ trait API {
 			$timeout = 60;
 
 			// Set timeout to GitHub rate limit reset.
-			$timeout             = $this->ratelimit_reset( $response, $this->repo->slug );
+			$timeout             = static::ratelimit_reset( $response, $this->repo->slug );
 			$response['timeout'] = $timeout;
 			$this->set_repo_cache( 'error_cache', $response, md5( $url ), "+{$timeout} minutes" );
 		}
@@ -131,7 +131,7 @@ trait API {
 			]
 		);
 		if ( isset( $response['timeout'] ) ) {
-			static::$error_code[ $this->repo->slug ]['wait'] = $this->ratelimit_reset( $response, $this->repo->slug );
+			static::$error_code[ $this->repo->slug ]['wait'] = static::ratelimit_reset( $response, $this->repo->slug );
 		}
 
 		if ( isset( $response['timeout'] ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/vendor/afragen/translations-updater/src/Translations_Updater/API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/API.php
@@ -138,7 +138,7 @@ trait API {
 		if ( isset( $response['timeout'] ) && ! $cached && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			$response_body = json_decode( wp_remote_retrieve_body( $response ) );
 			if ( null !== $response_body && property_exists( $response_body, 'message' ) ) {
-				$log_message = "Translations Updater Error: {$this->repo->name} ({$this->repo->slug}:{$this->repo->branch}) - {$response_body->message}";
+				$log_message = "Translations Updater Error: {$this->repo->slug} - {$response_body->message}";
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( $log_message );
 			}

--- a/vendor/afragen/translations-updater/src/Translations_Updater/API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/API.php
@@ -133,9 +133,8 @@ trait API {
 		if ( isset( $response['timeout'] ) ) {
 			static::$error_code[ $this->repo->slug ]['wait'] = $response['timeout'];
 		}
-		// Singleton::get_instance( 'Messages', $this )->create_error_message( $type['git'] );
 
-		if ( isset( $response['timeout'] ) && ! $cached && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		if ( isset( $response['timeout'] ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			$response_body = json_decode( wp_remote_retrieve_body( $response ) );
 			if ( null !== $response_body && property_exists( $response_body, 'message' ) ) {
 				$log_message = "Translations Updater Error: {$this->repo->slug} - {$response_body->message}";

--- a/vendor/afragen/translations-updater/src/Translations_Updater/API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/API.php
@@ -214,12 +214,12 @@ trait API {
 	 *
 	 * @return bool
 	 */
-	final protected function set_repo_cache( $id, $response, $repo = false ) {
+	final protected function set_repo_cache( $id, $response, $repo = false, $timeout = false ) {
 		if ( ! $repo ) {
 			$repo = isset( $this->repo->slug ) ? $this->repo->slug : 'tu';
 		}
 		$cache_key = 'tu-' . md5( $repo );
-		$timeout   = '+' . self::$hours . ' hours';
+		$timeout   = $timeout ?  $timeout : '+' . static::$hours . ' hours';
 
 		$this->response['timeout'] = strtotime( $timeout );
 		$this->response[ $id ]     = $response;

--- a/vendor/afragen/translations-updater/src/Translations_Updater/API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/API.php
@@ -38,6 +38,13 @@ trait API {
 	protected $response = [];
 
 	/**
+	 * Holds HTTP error code from API call.
+	 *
+	 * @var array ( $this->repo->slug => $code )
+	 */
+	protected static $error_code = [];
+
+	/**
 	 * Return repo data for API calls.
 	 *
 	 * @return array
@@ -82,10 +89,59 @@ trait API {
 	 * @return boolean|\stdClass
 	 */
 	final protected function api( $url ) {
-		$response = wp_remote_get( $this->get_api_url( $url ) );
+		$url  = $this->get_api_url( $url );
+		$args = [];
+
+		// Use cached API failure data to avoid hammering the API.
+		$response = $this->get_repo_cache( md5( $url ) );
+		$cached   = isset( $response['error_cache'] );
+		$response = $response ? $response['error_cache'] : $response;
+		$response = empty( $response )
+			? wp_remote_get( $url, $args )
+			: $response;
+
+		$code          = (int) wp_remote_retrieve_response_code( $response );
+		$allowed_codes = [ 200 ];
 
 		if ( is_wp_error( $response ) ) {
-			return false;
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
+			error_log( var_export( $response, true ) );
+
+			return $response;
+		}
+
+		// Cache HTTP API error code for 60 minutes.
+		if ( ! in_array( $code, $allowed_codes, true ) && ! $cached ) {
+			$timeout = 60;
+
+			// Set timeout to GitHub rate limit reset.
+			$timeout             = $this->ratelimit_reset( $response, $this->repo->slug );
+			$response['timeout'] = $timeout;
+			$this->set_repo_cache( 'error_cache', $response, md5( $url ), "+{$timeout} minutes" );
+		}
+
+		static::$error_code[ $this->repo->slug ] = static::$error_code[ $this->repo->slug ] ?? [];
+		static::$error_code[ $this->repo->slug ] = array_merge(
+			static::$error_code[ $this->repo->slug ],
+			[
+				'repo' => $this->repo->slug,
+				'code' => $code,
+				'name' => $this->repo->name ?? $this->repo->slug,
+				'git'  => $this->repo->git,
+			]
+		);
+		if ( isset( $response['timeout'] ) ) {
+			static::$error_code[ $this->repo->slug ]['wait'] = $response['timeout'];
+		}
+		// Singleton::get_instance( 'Messages', $this )->create_error_message( $type['git'] );
+
+		if ( isset( $response['timeout'] ) && ! $cached && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$response_body = json_decode( wp_remote_retrieve_body( $response ) );
+			if ( null !== $response_body && property_exists( $response_body, 'message' ) ) {
+				$log_message = "Translations Updater Error: {$this->repo->name} ({$this->repo->slug}:{$this->repo->branch}) - {$response_body->message}";
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( $log_message );
+			}
 		}
 
 		return json_decode( wp_remote_retrieve_body( $response ) );
@@ -137,7 +193,7 @@ trait API {
 	 */
 	final protected function get_repo_cache( $repo = false ) {
 		if ( ! $repo ) {
-			$repo = isset( $this->type->slug ) ? $this->type->slug : 'tu';
+			$repo = isset( $this->repo->slug ) ? $this->repo->slug : 'tu';
 		}
 		$cache_key = 'tu-' . md5( $repo );
 		$cache     = get_site_option( $cache_key );
@@ -160,7 +216,7 @@ trait API {
 	 */
 	final protected function set_repo_cache( $id, $response, $repo = false ) {
 		if ( ! $repo ) {
-			$repo = isset( $this->type->slug ) ? $this->type->slug : 'tu';
+			$repo = isset( $this->repo->slug ) ? $this->repo->slug : 'tu';
 		}
 		$cache_key = 'tu-' . md5( $repo );
 		$timeout   = '+' . self::$hours . ' hours';
@@ -171,5 +227,28 @@ trait API {
 		update_site_option( $cache_key, $this->response );
 
 		return true;
+	}
+
+	/**
+	 * Calculate and store time until rate limit reset.
+	 *
+	 * @param array  $response HTTP headers.
+	 * @param string $repo     Repo name.
+	 *
+	 * @return void|int
+	 */
+	final public static function ratelimit_reset( $response, $repo ) {
+		$headers = wp_remote_retrieve_headers( $response );
+		$data    = $headers->getAll();
+		$wait    = 0;
+		if ( isset( $data['x-ratelimit-reset'] ) ) {
+			$reset = (int) $data['x-ratelimit-reset'];
+			//phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+			$wait                        = date( 'i', $reset - time() );
+			static::$error_code[ $repo ] = static::$error_code[ $repo ] ?? [];
+			static::$error_code[ $repo ] = array_merge( static::$error_code[ $repo ], [ 'wait' => $wait ] );
+
+			return $wait;
+		}
 	}
 }

--- a/vendor/afragen/translations-updater/src/Translations_Updater/API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/API.php
@@ -131,13 +131,14 @@ trait API {
 			]
 		);
 		if ( isset( $response['timeout'] ) ) {
-			static::$error_code[ $this->repo->slug ]['wait'] = $response['timeout'];
+			static::$error_code[ $this->repo->slug ]['wait'] = $this->ratelimit_reset( $response, $this->repo->slug );
 		}
 
 		if ( isset( $response['timeout'] ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			$response_body = json_decode( wp_remote_retrieve_body( $response ) );
 			if ( null !== $response_body && property_exists( $response_body, 'message' ) ) {
-				$log_message = "Translations Updater Error: {$this->repo->slug} - {$response_body->message}";
+				$log_message = "Translations Updater Error: {$this->repo->slug} - {$response_body->message}"
+				. "\nTime remaining for rate limiting:  {$this->ratelimit_reset($response, $this->repo->slug)} minutes";
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( $log_message );
 			}
@@ -218,7 +219,7 @@ trait API {
 			$repo = isset( $this->repo->slug ) ? $this->repo->slug : 'tu';
 		}
 		$cache_key = 'tu-' . md5( $repo );
-		$timeout   = $timeout ?  $timeout : '+' . static::$hours . ' hours';
+		$timeout   = $timeout ? $timeout : '+' . static::$hours . ' hours';
 
 		$this->response['timeout'] = strtotime( $timeout );
 		$this->response[ $id ]     = $response;

--- a/vendor/afragen/translations-updater/src/Translations_Updater/Language_Pack.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/Language_Pack.php
@@ -58,8 +58,11 @@ class Language_Pack {
 	 * Do the Language Pack integration.
 	 */
 	public function run() {
-		$headers                     = $this->parse_header_uri( $this->repo->languages );
-		$repo                        = $this->repo_api->get_language_pack( $headers );
+		$headers = $this->parse_header_uri( $this->repo->languages );
+		$repo    = $this->repo_api->get_language_pack( $headers );
+		if ( is_wp_error( $repo ) ) {
+			return;
+		}
 		$this->config[ $repo->slug ] = $repo;
 
 		add_filter( 'site_transient_update_plugins', [ $this, 'update_site_transient' ] );

--- a/vendor/afragen/translations-updater/src/Translations_Updater/Language_Pack_API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/Language_Pack_API.php
@@ -47,7 +47,7 @@ class Language_Pack_API {
 	 *
 	 * @param array $headers Array of headers of Language Pack.
 	 *
-	 * @return bool When invalid response.
+	 * @return \stdClass
 	 */
 	public function get_language_pack( $headers ) {
 		$response = ! empty( $this->response['languages'] ) ? $this->response['languages'] : false;
@@ -64,11 +64,9 @@ class Language_Pack_API {
 					$response->{$locale->language}->version = $this->repo->version;
 				}
 				$this->set_repo_cache( 'languages', $response, $this->repo->slug );
-			} else {
-				return false;
 			}
 		}
-		$this->repo->language_packs = $response;
+		$this->repo->language_packs = $response ? $response : new \stdClass();
 
 		return $this->repo;
 	}
@@ -124,7 +122,7 @@ class Language_Pack_API {
 	 * @param \stdClass $locale  Site locale.
 	 * @param array     $headers Repository headers.
 	 *
-	 * @return array|null|string
+	 * @return string
 	 */
 	private function process_language_pack_package( $git, $locale, $headers ) {
 		$package = null;

--- a/vendor/afragen/translations-updater/src/Translations_Updater/Language_Pack_API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/Language_Pack_API.php
@@ -64,9 +64,11 @@ class Language_Pack_API {
 					$response->{$locale->language}->version = $this->repo->version;
 				}
 				$this->set_repo_cache( 'languages', $response, $this->repo->slug );
+			} else {
+				return new \WP_Error('language_pack_validation_error', 'Language Pack validation error.' );
 			}
 		}
-		$this->repo->language_packs = $response ? $response : new \stdClass();
+		$this->repo->language_packs = $response;
 
 		return $this->repo;
 	}

--- a/vendor/afragen/translations-updater/src/Translations_Updater/Language_Pack_API.php
+++ b/vendor/afragen/translations-updater/src/Translations_Updater/Language_Pack_API.php
@@ -47,7 +47,7 @@ class Language_Pack_API {
 	 *
 	 * @param array $headers Array of headers of Language Pack.
 	 *
-	 * @return \stdClass
+	 * @return \stdClass|\WP_Error
 	 */
 	public function get_language_pack( $headers ) {
 		$response = ! empty( $this->response['languages'] ) ? $this->response['languages'] : false;
@@ -65,7 +65,11 @@ class Language_Pack_API {
 				}
 				$this->set_repo_cache( 'languages', $response, $this->repo->slug );
 			} else {
-				return new \WP_Error('language_pack_validation_error', 'Language Pack validation error.' );
+				return new \WP_Error(
+					'language_pack_validation_error',
+					'API timeout error',
+					[ self::$error_code ]
+				);
 			}
 		}
 		$this->repo->language_packs = $response;


### PR DESCRIPTION
Added API error caching for 60 min as GitHub API rate limits unauthenticated requests for 60 requests/hour. Leaves an entry in the debug.log