### PR TITLE
fix version reference of GA

### DIFF
--- a/.github/workflows/generate-pot.yml
+++ b/.github/workflows/generate-pot.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - translations
-    tags:
-      - "**"
 
 jobs:
   WP_POT_Generator:
@@ -15,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: WordPress POT Generator
-        uses: varunsridharan/action-wp-pot-generator@^2
+        uses: varunsridharan/action-wp-pot-generator@2
         with:
           save_path: "./languages"
           item_slug: "${{ github.event.repository.name }}"


### PR DESCRIPTION
Fixed reference to `varunsridharan/action-wp-pot-generator`

Fixes #203 