### PR TITLE
Set POT generation action version to `2.0`.

### DIFF
--- a/.github/workflows/generate-pot.yml
+++ b/.github/workflows/generate-pot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: WordPress POT Generator
-        uses: varunsridharan/action-wp-pot-generator@2
+        uses: varunsridharan/action-wp-pot-generator@2.0
         with:
           save_path: "./languages"
           item_slug: "${{ github.event.repository.name }}"


### PR DESCRIPTION
# Pull Request

## What changed?

Changed the version reference of the POT generation action from `@2` to `@2.0`.

## Why did it change?

The action was failing and its readme states `@2.0`.

## Did you fix any specific issues?

Fixes #203 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

