### PR TITLE
Add write permissions to POT generation workflow.

### DIFF
--- a/.github/workflows/generate-pot.yml
+++ b/.github/workflows/generate-pot.yml
@@ -10,6 +10,8 @@ jobs:
   WP_POT_Generator:
     if: github.repository == 'aspirepress/aspireupdate'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@master
       - name: WordPress POT Generator


### PR DESCRIPTION
# Pull Request

## What changed?

Added write permissions for the POT generation workflow.

## Why did it change?

GitHub Actions bot doesn't have write permissions by default.

## Did you fix any specific issues?

Fixes #203 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

