### PR TITLE
Don't export the `.cache` directory.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@ phpcs.xml.dist export-ignore
 /.github export-ignore
 /bin export-ignore
 /tests export-ignore
+/.cache export-ignore


### PR DESCRIPTION
# Pull Request

## What changed?

Added an `export-ignore` rule for the `.cache` directory in `.gitattributes`.

## Why did it change?

While this file is needed for development, it should not be included in release builds.

## Did you fix any specific issues?

Fixes #189 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

