### PR TITLE
Introduce and implement `AdminSettings_UnitTestCase`

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -58,4 +58,12 @@
 
 	<!-- Enforce short syntax arrays. -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+	<!-- Exclude test classes from naming conventions. -->
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>/tests/phpunit/tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>/tests/phpunit/tests/*</exclude-pattern>
+	</rule>
 </ruleset>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -39,3 +39,6 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";
+
+// Load unit test abstract classes.
+require __DIR__ . '/includes/AdminSettings_UnitTestCase.php';

--- a/tests/phpunit/includes/AdminSettings_UnitTestCase.php
+++ b/tests/phpunit/includes/AdminSettings_UnitTestCase.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Abstract base test class for \AspireUpdate\Admin_Settings.
+ *
+ * All \AspireUpdate\Admin_Settings unit tests should inherit from this class.
+ */
+abstract class AdminSettings_UnitTestCase extends WP_UnitTestCase {
+	/**
+	 * The Name of the Option.
+	 *
+	 * @var string
+	 */
+	protected static $option_name = 'aspireupdate_settings';
+
+	/**
+	 * Deletes settings before each test runs.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		delete_site_option( self::$option_name );
+	}
+}

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_GetSettingTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_GetSettingTest.php
@@ -10,7 +10,7 @@
  *
  * @covers \AspireUpdate\Admin_Settings::get_setting
  */
-class AdminSettings_GetSettingTest extends WP_UnitTestCase {
+class AdminSettings_GetSettingTest extends AdminSettings_UnitTestCase {
 	/**
 	 * Test that the default 'api_host' value is retrieved.
 	 *


### PR DESCRIPTION
# Pull Request

## What changed?

- A new unit test case has been introduced: `AdminSettings_UnitTestCase`.
- The new unit test case has been implemented in `AdminSettings_GetSettingTest`.

## Why did it change?

To reduce repetition and the maintenance burden.

## Did you fix any specific issues?

Fixes #212

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

