### PR TITLE
Use the full domain name

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/autoloader.git",
-                "reference": "ec56498d42f0694d3ad1207a496bf69cbb0ebc2f"
+                "reference": "ab30ab542c48fe3ecd26c3bda28fef544f04b401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/autoloader/zipball/ec56498d42f0694d3ad1207a496bf69cbb0ebc2f",
-                "reference": "ec56498d42f0694d3ad1207a496bf69cbb0ebc2f",
+                "url": "https://api.github.com/repos/afragen/autoloader/zipball/ab30ab542c48fe3ecd26c3bda28fef544f04b401",
+                "reference": "ab30ab542c48fe3ecd26c3bda28fef544f04b401",
                 "shasum": ""
             },
             "require": {
@@ -43,9 +43,9 @@
             ],
             "support": {
                 "issues": "https://github.com/afragen/autoloader/issues",
-                "source": "https://github.com/afragen/autoloader/tree/master"
+                "source": "https://github.com/afragen/autoloader/tree/3.0.0"
             },
-            "time": "2024-11-10T22:55:51+00:00"
+            "time": "2024-11-27T02:42:42+00:00"
         },
         {
             "name": "afragen/translations-updater",

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -324,7 +324,7 @@ class Admin_Settings {
 			[
 				'ajax_url'         => network_admin_url( 'admin-ajax.php' ),
 				'nonce'            => wp_create_nonce( 'aspireupdate-ajax' ),
-				'domain'           => Utilities::get_top_level_domain(),
+				'domain'           => Utilities::get_site_domain(),
 				'line_ending'      => PHP_EOL,
 				'unexpected_error' => esc_html__( 'Unexpected Error', 'aspireupdate' ),
 			]

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -14,7 +14,7 @@ class Utilities {
 	/**
 	 * Get the domain name from the site URL.
 	 *
-	 * @return string the domain name.
+	 * @return string The domain name.
 	 */
 	public static function get_site_domain() {
 		$site_url = network_site_url();

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -17,7 +17,7 @@ class Utilities {
 	 * @return string the domain name.
 	 */
 	public static function get_site_domain() {
-		$site_url = get_site_url();
+		$site_url = network_site_url();
 		return wp_parse_url( $site_url, PHP_URL_HOST );
 	}
 

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -11,17 +11,14 @@ namespace AspireUpdate;
  * The Class for Admin Settings Page and functions to access Settings Values.
  */
 class Utilities {
-
 	/**
-	 * Get the top level domain name from the site URL.
+	 * Get the domain name from the site URL.
 	 *
-	 * @return string the top level domain name.
+	 * @return string the domain name.
 	 */
-	public static function get_top_level_domain() {
-		$site_url     = get_site_url();
-		$domain_name  = wp_parse_url( $site_url, PHP_URL_HOST );
-		$domain_parts = explode( '.', $domain_name );
-		return sanitize_text_field( implode( '.', array_slice( $domain_parts, -2 ) ) );
+	public static function get_site_domain() {
+		$site_url = get_site_url();
+		return wp_parse_url( $site_url, PHP_URL_HOST );
 	}
 
 	/**


### PR DESCRIPTION
Use the full domain name instead of attempting to extract the top level TLD

# Pull Request

## What changed?

Changed behavior of API Key call to use the full domain name instead of trying to extract the top TLD which can lead to parsing issues

## Why did it change?

Extracting the top TLD was an unnecessary complication which is not required.

## Did you fix any specific issues?

Fixes #194 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

