### PR TITLE
Add tests for `Controller::__construct()`

### DIFF
--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -27,6 +27,8 @@ class Controller {
 	/**
 	 * Enable API Rewrites based on the Users settings.
 	 *
+	 * @codeCoverageIgnore Side-effects are from other methods already covered by tests.
+	 *
 	 * @return void
 	 */
 	private function api_rewrite() {

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -54,6 +54,8 @@ class Controller {
 	/**
 	 * Ajax action to clear the Log file.
 	 *
+	 * @codeCoverageIgnore Cannot be tested. Results in script termination.
+	 *
 	 * @return void
 	 */
 	public function clear_log() {
@@ -83,6 +85,8 @@ class Controller {
 
 	/**
 	 * Ajax action to read the Log file.
+	 *
+	 * @codeCoverageIgnore Cannot be tested. Results in script termination.
 	 *
 	 * @return void
 	 */

--- a/tests/phpunit/tests/Controller/Controller_ConstructTest.php
+++ b/tests/phpunit/tests/Controller/Controller_ConstructTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Class Controller_ConstructTest
+ *
+ * @package AspireUpdate
+ */
+
+/**
+ * Tests for Controller::__construct()
+ *
+ * @covers \AspireUpdate\Controller::__construct
+ */
+class Controller_ConstructTest extends WP_UnitTestCase {
+	/**
+	 * Test that hooks are added.
+	 *
+	 * @dataProvider data_hooks_and_methods
+	 *
+	 * @string $hook   The hook's name.
+	 * @string $method The method to hook.
+	 */
+	public function test_should_add_hooks( $hook, $method ) {
+		$controller = new AspireUpdate\Controller();
+		$this->assertIsInt( has_action( $hook, [ $controller, $method ] ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_hooks_and_methods() {
+		return [
+			'wp_ajax_aspireupdate_clear_log -> clear_log' => [
+				'hook'   => 'wp_ajax_aspireupdate_clear_log',
+				'method' => 'clear_log',
+			],
+			'wp_ajax_aspireupdate_read_log -> read_log'   => [
+				'hook'   => 'wp_ajax_aspireupdate_read_log',
+				'method' => 'read_log',
+			],
+		];
+	}
+}


### PR DESCRIPTION
# Pull Request

## What changed?

- Added tests for `Controller::__construct()`
- Added `@codeCoverageIgnore` annotations to:
  - `Controller::api_rewrite()`
  - `Controller::clear_log()`
  - `Controller::read_log()`

## Why did it change?

To improve PHPUnit test coverage.

## Did you fix any specific issues?

See #216 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

