### PR TITLE
Add tests for `Plugins_Screens::remove_unused_filter_tabs()`

### DIFF
--- a/tests/phpunit/tests/PluginsScreens/PluginsScreens_RemoveUnusedFilterTabsTest.php
+++ b/tests/phpunit/tests/PluginsScreens/PluginsScreens_RemoveUnusedFilterTabsTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Class PluginsScreens_RemoveUnusedFilterTabsTest
+ *
+ * @package AspireUpdate
+ */
+
+/**
+ * Tests for Plugins_Screens::remove_unused_filter_tabs()
+ *
+ * @covers \AspireUpdate\Plugins_Screens::remove_unused_filter_tabs
+ */
+class PluginsScreens_RemoveUnusedFilterTabsTest extends WP_UnitTestCase {
+	/**
+	 * Test that unused filter tabs are removed.
+	 */
+	public function test_should_remove_unused_filter_tabs() {
+		$plugins_screens = new AspireUpdate\Plugins_Screens();
+		$reflected       = new ReflectionProperty(
+			$plugins_screens,
+			'unsupported_filters'
+		);
+		$reflected->setAccessible( true );
+		$unsupported = $reflected->getValue( $plugins_screens );
+		$reflected->setAccessible( false );
+
+		$supported = [
+			'tab1' => true,
+			'tab2' => true,
+			'tab3' => true,
+		];
+
+		$tabs = $supported;
+		foreach ( $unsupported as $tab ) {
+			$tabs[ $tab ] = true;
+		}
+
+		$this->assertSame(
+			$supported,
+			$plugins_screens->remove_unused_filter_tabs( $tabs )
+		);
+	}
+}


### PR DESCRIPTION
# Pull Request

## What changed?

- Added tests for `Plugins_Screens::remove_unused_filter_tabs()`

## Why did it change?

To improve PHPUnit test coverage.

## Did you fix any specific issues?

See #216 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

