### PR TITLE
Add tests for `Utilities::include_file()`

### DIFF
--- a/tests/phpunit/tests/Utilities/Utilities_IncludeFileTest.php
+++ b/tests/phpunit/tests/Utilities/Utilities_IncludeFileTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Class Utilities_IncludeFileTest
+ *
+ * @package AspireUpdate
+ */
+
+/**
+ * Tests for Utilities::include_file()
+ *
+ * @covers \AspireUpdate\Utilities::include_file
+ */
+class Utilities_IncludeFileTest extends WP_UnitTestCase {
+	/**
+	 * Test that a file is not included when an empty path has been provided.
+	 */
+	public function test_should_not_include_file_when_path_is_empty() {
+		$output = get_echo( [ 'AspireUpdate\Utilities', 'include_file' ], [ '' ] );
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that a file is not included when it does not exist.
+	 */
+	public function test_should_not_include_file_when_file_does_not_exist() {
+		$output = get_echo( [ 'AspireUpdate\Utilities', 'include_file' ], [ 'non-existent-file.php' ] );
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that a file is included.
+	 */
+	public function test_should_include_file() {
+		$output = get_echo( [ 'AspireUpdate\Utilities', 'include_file' ], [ 'page-admin-settings.php' ] );
+		$this->assertNotEmpty( $output );
+	}
+}


### PR DESCRIPTION
# Pull Request

## What changed?

- Added tests for `Utilities::include_file()`

## Why did it change?

To improve PHPUnit test coverage.

## Did you fix any specific issues?

See #216 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

