### PR TITLE
Add tests for `Admin_Settings::get_instance()`

### DIFF
--- a/tests/phpunit/tests/AdminSettings/AdminSettings_GetInstanceTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_GetInstanceTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class AdminSettings_GetInstanceTest
+ *
+ * @package AspireUpdate
+ */
+
+/**
+ * Tests for Admin_Settings::get_instance()
+ *
+ * These tests rely on the method not being called during earlier test runs.
+ * They must run in separate processes and must not preserve global state.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ *
+ * @covers \AspireUpdate\Admin_Settings::get_instance
+ */
+class AdminSettings_GetInstanceTest extends AdminSettings_UnitTestCase {
+	/**
+	 * Test that the same instance is retrieved.
+	 */
+	public function test_should_get_the_same_instance() {
+		$this->assertSame(
+			AspireUpdate\Admin_Settings::get_instance(),
+			AspireUpdate\Admin_Settings::get_instance()
+		);
+	}
+}


### PR DESCRIPTION
# Pull Request

## What changed?

Added tests for `Admin_Settings::get_instance()`

## Why did it change?

To improve PHPUnit test coverage.

## Did you fix any specific issues?

See #216

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

