### PR TITLE
Add tests for `Admin_Settings::delete_all_settings()`

### DIFF
--- a/tests/phpunit/tests/AdminSettings/AdminSettings_DeleteAllSettingsTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_DeleteAllSettingsTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Class AdminSettings_DeleteAllSettingsTest
+ *
+ * @package AspireUpdate
+ */
+
+/**
+ * Tests for Admin_Settings::delete_all_settings()
+ *
+ * @covers \AspireUpdate\Admin_Settings::delete_all_settings
+ */
+class AdminSettings_DeleteAllSettingsTest extends AdminSettings_UnitTestCase {
+	/**
+	 * Test that all settings are deleted.
+	 */
+	public function test_should_delete_all_settings() {
+		$settings = [
+			'enable'                   => true,
+			'api_host'                 => 'the.api.host',
+			'api_key'                  => 'tHeApIkEy',
+			'enable_debug'             => true,
+			'enable_debug_types'       => [ 'response' => true ],
+			'disable_ssl_verification' => true,
+		];
+
+		$this->assertTrue(
+			update_site_option( self::$option_name, $settings ),
+			'Settings were not set before the test.'
+		);
+
+		$admin_settings = new \AspireUpdate\Admin_Settings();
+
+		$admin_settings->delete_all_settings();
+		$this->assertFalse(
+			get_site_option( self::$option_name, false ),
+			'Settings were not deleted.'
+		);
+	}
+}


### PR DESCRIPTION
# Pull Request

## What changed?

Added tests for `Admin_Settings::delete_all_settings()`

## Why did it change?

To improve PHPUnit test coverage.

## Did you fix any specific issues?

See #216

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

