### PR TITLE
Add tests for `Admin_Settings::the_settings_page()`

### DIFF
--- a/tests/phpunit/tests/AdminSettings/AdminSettings_TheSettingsPageTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_TheSettingsPageTest.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Class AdminSettings_TheSettingsPageTest
+ *
+ * @package AspireUpdate
+ */
+
+/**
+ * Tests for Admin_Settings::the_settings_page()
+ *
+ * @covers \AspireUpdate\Admin_Settings::the_settings_page
+ */
+class AdminSettings_TheSettingsPageTest extends AdminSettings_UnitTestCase {
+	/**
+	 * Test that the settings page is output.
+	 */
+	public function test_should_output_settings_page() {
+		$admin_settings = new AspireUpdate\Admin_Settings();
+		$actual         = get_echo( [ $admin_settings, 'the_settings_page' ] );
+
+		$this->assertStringContainsString( 'AspireUpdate Settings', $actual );
+	}
+}


### PR DESCRIPTION
# Pull Request

## What changed?

Added tests for `Admin_Settings::the_settings_page()`

## Why did it change?

To improve PHPUnit test coverage.

## Did you fix any specific issues?

See #216

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

