### PR TITLE
Add tests for `Debug::clear()`

### DIFF
--- a/tests/phpunit/tests/Debug/Debug_ClearTest.php
+++ b/tests/phpunit/tests/Debug/Debug_ClearTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Class Debug_ClearTest
+ *
+ * @package AspireUpdate
+ */
+
+/**
+ * Tests for Debug::clear()
+ *
+ * @covers \AspireUpdate\Debug::clear
+ */
+class Debug_ClearTest extends Debug_UnitTestCase {
+	/**
+	 * Test that a WP_Error object is returned when the filesystem isn't available.
+	 *
+	 * @covers \AspireUpdate\Debug::init_filesystem
+	 * @covers \AspireUpdate\Debug::verify_filesystem
+	 */
+	public function test_should_return_wp_error_when_filesystem_is_not_available() {
+		add_filter( 'filesystem_method', '__return_false' );
+
+		$this->assertWPError(
+			AspireUpdate\Debug::clear(),
+			'A WP_Error object was not returned.'
+		);
+
+		$this->assertFileDoesNotExist(
+			self::$log_file,
+			'The log file was created.'
+		);
+	}
+
+	/**
+	 * Test that a WP_Error object is returned when the log file doesn't exist.
+	 *
+	 * @covers \AspireUpdate\Debug::init_filesystem
+	 * @covers \AspireUpdate\Debug::verify_filesystem
+	 * @covers \AspireUpdate\Debug::get_file_path
+	 */
+	public function test_should_return_wp_error_when_log_file_does_not_exist() {
+		$this->assertWPError(
+			AspireUpdate\Debug::clear(),
+			'A WP_Error object was not returned.'
+		);
+
+		$this->assertFileDoesNotExist(
+			self::$log_file,
+			'The log file was created.'
+		);
+	}
+
+	/**
+	 * Test that a WP_Error object is returned when the log file isn't writable.
+	 *
+	 * @covers \AspireUpdate\Debug::init_filesystem
+	 * @covers \AspireUpdate\Debug::verify_filesystem
+	 * @covers \AspireUpdate\Debug::get_file_path
+	 */
+	public function test_should_return_wp_error_when_log_file_is_not_writable() {
+		global $wp_filesystem;
+
+		// Backup and replace the filesystem object.
+		$wp_filesystem = $this->get_fake_filesystem( true, true, false );
+
+		$actual = AspireUpdate\Debug::clear();
+
+		$this->assertWPError(
+			$actual,
+			'A WP_Error was not returned.'
+		);
+
+		$this->assertFileDoesNotExist(
+			self::$log_file,
+			'The log file was created.'
+		);
+	}
+
+	/**
+	 * Test that the log file is cleared.
+	 */
+	public function test_should_clear_log_file() {
+		file_put_contents(
+			self::$log_file,
+			"First line\r\nSecond line\r\nThird line"
+		);
+
+		$this->assertFileExists(
+			self::$log_file,
+			'The log file was not created before testing.'
+		);
+
+		AspireUpdate\Debug::clear();
+
+		$this->assertFileExists(
+			self::$log_file,
+			'The log file was deleted.'
+		);
+
+		$this->assertSame(
+			'',
+			file_get_contents( self::$log_file ),
+			'The log file was not cleared.'
+		);
+	}
+}


### PR DESCRIPTION
# Pull Request

## What changed?

- Added tests for `Debug::clear()`
  - Some of these tests also cover `Debug::init_filesystem()`, `Debug::verify_filesystem()`, and `Debug::get_file_path()`.

## Why did it change?

To improve PHPUnit test coverage.

## Did you fix any specific issues?

See #216

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.