### PR TITLE
Code Coverage: Ignore `Admin_Settings::add_settings_field_callback()`

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -506,6 +506,8 @@ class Admin_Settings {
 	/**
 	 * The Fields API which any CMS should have in its core but something we dont, hence this ugly hack.
 	 *
+	 * @codeCoverageIgnore Test with E2E tests instead.
+	 *
 	 * @param array $args The Field Parameters.
 	 *
 	 * @return void Echos the Field HTML.


### PR DESCRIPTION
This should be tested with E2E tests instead.

# Pull Request

## What changed?

Ignored `Admin_Settings::add_settings_field_callback()` from coverage reports.

## Why did it change?

To ensure this method doesn't unnecessarily affect coverage reports.

## Did you fix any specific issues?

See #216 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

