### PR TITLE
Workflows: Install SVN before running tests

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,6 +35,9 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: phpunit-polyfills:1.1
 
+      - name: Install SVN
+        run: sudo apt install -y subversion
+
       - name: Setup tests
         run: bash bin/install-wp-tests.sh wordpress_tests root root 127.0.0.1 latest true
 


### PR DESCRIPTION
# Pull Request

## What changed?

The PHPUnit test workflow now installs Subversion before setting up the tests.

## Why did it change?

Subversion was removed from GitHub Actions' default packages for Ubuntu 24, which causes PHPUnit test setup to fail.

## Did you fix any specific issues?

Fixes #253 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

