### PR TITLE
Workflows: Prime a WP install and skip install for the actual test run.

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -41,5 +41,10 @@ jobs:
       - name: Setup tests
         run: bash bin/install-wp-tests.sh wordpress_tests root root 127.0.0.1 latest true
 
+      - name: Prime the WordPress install for tests
+        id: prime-tests
+        run: XDEBUG_MODE=off phpunit${{ matrix.multisite && ' -c tests/phpunit/multisite.xml' || '' }} --filter gha_install_wp > /dev/null 2>&1
+
       - name: Run tests
-        run: XDEBUG_MODE=off phpunit${{ matrix.multisite && ' -c tests/phpunit/multisite.xml' || '' }}
+        if: steps.prime-tests.outcome == 'success'
+        run: XDEBUG_MODE=off WP_TESTS_SKIP_INSTALL=1 phpunit${{ matrix.multisite && ' -c tests/phpunit/multisite.xml' || '' }}


### PR DESCRIPTION
# Pull Request

## What changed?

The PHPUnit test workflow now performs a dummy run to prime the WordPress install for tests.

When this completes, the actual test run is performed, with the `WP_TESTS_SKIP_INSTALL` environment variable set to `1`.

## Why did it change?

Since many of the tests must run in separate processes, the WordPress installation occurs _in each process_. This is an unnecessary delay. By priming the install and explicitly disabling the install attempts in the actual runs, this delay is removed.

Also, it's nice to have nice things.

## Did you fix any specific issues?

Fixes #257

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

