### PR TITLE
change default API host from .org to .net

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -74,7 +74,7 @@ class Admin_Settings {
 	 */
 	private function get_default_settings() {
 		$options             = [];
-		$options['api_host'] = 'api.aspirecloud.org';
+		$options['api_host'] = 'api.aspirecloud.net';
 		return $options;
 	}
 


### PR DESCRIPTION
# Pull Request

## What changed?

Changed the default API host from api.aspirecloud.org to api.aspirecloud.net

## Why did it change?

api.aspirecloud.org does not exist.  For usability and convenience, the default api host should point to the AspireCloud production server api.

## Did you fix any specific issues?

Fixes #265 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

