### PR TITLE
Follow up to #268

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -43,7 +43,8 @@ class API_Rewrite {
 	 * The Constructor.
 	 *
 	 * @param string  $redirected_host The host to redirect to.
-	 * @param boolean $disable_ssl Disable SSL.
+	 * @param boolean $disable_ssl     Disable SSL.
+	 * @param string  $api_key         The API key to use with the host.
 	 */
 	public function __construct( $redirected_host, $disable_ssl, $api_key ) {
 		if ( 'debug' === $redirected_host ) {

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_ConstructTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_ConstructTest.php
@@ -20,7 +20,7 @@ class APIRewrite_ConstructTest extends WP_UnitTestCase {
 	 * @string $method The method to hook.
 	 */
 	public function test_should_add_hooks( $hook, $method ) {
-		$api_rewrite = new AspireUpdate\API_Rewrite( 'debug', false );
+		$api_rewrite = new AspireUpdate\API_Rewrite( 'debug', false, '' );
 		$this->assertIsInt( has_action( $hook, [ $api_rewrite, $method ] ) );
 	}
 
@@ -50,7 +50,8 @@ class APIRewrite_ConstructTest extends WP_UnitTestCase {
 	public function test_should_set_properties( $property_name, $passed_value, $expected_value ) {
 		$api_rewrite = new AspireUpdate\API_Rewrite(
 			'redirected_host' === $property_name ? $passed_value : 'debug',
-			'disable_ssl' === $property_name ? $passed_value : false
+			'disable_ssl' === $property_name ? $passed_value : false,
+			''
 		);
 
 		if ( '%DEFAULT_HOST%' === $expected_value ) {

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -114,6 +114,60 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the API Key is added to the Authorization header.
+	 */
+	public function test_should_add_api_key_to_authorization_header_when_present() {
+		$actual = [];
+
+		add_filter(
+			'pre_http_request',
+			static function ( $response, $parsed_args ) use ( &$actual ) {
+				$actual = $parsed_args;
+				return $response;
+			},
+			10,
+			2
+		);
+
+		$api_key     = 'MY_API_KEY';
+		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', true, $api_key );
+		$api_rewrite->pre_http_request( [], [], $this->get_default_host() );
+
+		$this->assertIsArray(
+			$actual,
+			'Parsed arguments is not an array.'
+		);
+
+		$this->assertArrayHasKey(
+			'headers',
+			$actual,
+			'The "headers" key is not present.'
+		);
+
+		$this->assertIsArray(
+			$actual['headers'],
+			'The "headers" value is not an array.'
+		);
+
+		$this->assertArrayHasKey(
+			'Authorization',
+			$actual['headers'],
+			'There is no authorization header.'
+		);
+
+		$this->assertIsString(
+			$actual['headers']['Authorization'],
+			'The authorization header is not a string.'
+		);
+
+		$this->assertSame(
+			"Bearer $api_key",
+			$actual['headers']['Authorization'],
+			'The authorization header is wrong.'
+		);
+	}
+
+	/**
 	 * Gets the default host.
 	 *
 	 * @return string The default host.

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -18,7 +18,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		$request = new MockAction();
 		add_filter( 'pre_http_request', [ $request, 'filter' ] );
 
-		$api_rewrite = new AspireUpdate\API_Rewrite( '', false );
+		$api_rewrite = new AspireUpdate\API_Rewrite( '', false, '' );
 		$api_rewrite->pre_http_request( [], [], '' );
 
 		$this->assertSame( 0, $request->get_call_count() );
@@ -32,7 +32,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $request, 'filter' ] );
 
 		$default_host = $this->get_default_host();
-		$api_rewrite  = new AspireUpdate\API_Rewrite( $default_host, false );
+		$api_rewrite  = new AspireUpdate\API_Rewrite( $default_host, false, '' );
 
 		$api_rewrite->pre_http_request( [], [], $default_host );
 
@@ -55,7 +55,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 			2
 		);
 
-		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', false );
+		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', false, '' );
 		$api_rewrite->pre_http_request(
 			[],
 			[ 'sslverify' => 'original_sslverify_value' ],
@@ -81,7 +81,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 			2
 		);
 
-		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', true );
+		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', true, '' );
 		$api_rewrite->pre_http_request(
 			[],
 			[ 'sslverify' => true ],
@@ -107,10 +107,10 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 			3
 		);
 
-		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', true );
+		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', true, '' );
 		$api_rewrite->pre_http_request( [], [], $this->get_default_host() );
 
-		$this->assertSame( 'my.api.org', $actual );
+		$this->assertMatchesRegularExpression( '/my\.api\.org\?cache_buster=[0-9]+/', $actual );
 	}
 
 	/**


### PR DESCRIPTION
# Pull Request

## What changed?

- Documented the new `$api_key` parameter of `API_Rewrite::__construct()`.
- Fixed tests broken by changes made in #268.
- Add a test to ensure the API key is added to the `Authorization` header.

## Why did it change?

- Missing documentation.
- Broken tests.
- Reduced code coverage.

## Did you fix any specific issues?

See #268 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

