### PR TITLE
Add capability checks

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -266,7 +266,12 @@ class Admin_Settings {
 	 */
 	public function update_settings() {
 		// Exit if improper privileges.
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['_wpnonce'] ) ), 'aspireupdate-settings' ) ) {
+		$capability = is_multisite() ? 'manage_network_options' : 'manage_options';
+		if (
+			! current_user_can( $capability ) ||
+			! isset( $_POST['_wpnonce'] ) ||
+			! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['_wpnonce'] ) ), 'aspireupdate-settings' )
+		) {
 			return;
 		}
 

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -84,7 +84,9 @@ class Admin_Settings {
 	 * @return void
 	 */
 	public function reset_settings() {
+		$capability = is_multisite() ? 'manage_network_options' : 'manage_options';
 		if (
+			current_user_can( $capability ) &&
 			isset( $_GET['reset'] ) &&
 			( 'reset' === $_GET['reset'] ) &&
 			isset( $_GET['reset-nonce'] ) &&

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -125,6 +125,11 @@ class Admin_Settings {
 	 * @return void
 	 */
 	public function admin_notices() {
+		$capability = is_multisite() ? 'manage_network_options' : 'manage_options';
+		if ( ! current_user_can( $capability ) ) {
+			return;
+		}
+
 		/**
 		 * The Admin Notice to convey a Reset Operation has happened.
 		 */

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -60,7 +60,12 @@ class Controller {
 	 * @return void
 	 */
 	public function clear_log() {
-		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), 'aspireupdate-ajax' ) ) {
+		$capability = is_multisite() ? 'manage_network_options' : 'manage_options';
+		if (
+			! current_user_can( $capability ) ||
+			! isset( $_POST['nonce'] ) ||
+			! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), 'aspireupdate-ajax' )
+		) {
 			wp_send_json_error(
 				[
 					'message' => __( 'Error: You are not authorized to access this resource.', 'aspireupdate' ),

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -97,7 +97,12 @@ class Controller {
 	 * @return void
 	 */
 	public function read_log() {
-		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), 'aspireupdate-ajax' ) ) {
+		$capability = is_multisite() ? 'manage_network_options' : 'manage_options';
+		if (
+			! current_user_can( $capability ) ||
+			! isset( $_POST['nonce'] ) ||
+			! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), 'aspireupdate-ajax' )
+		) {
 			wp_send_json_error(
 				[
 					'message' => __( 'Error: You are not authorized to access this resource.', 'aspireupdate' ),

--- a/tests/phpunit/includes/AdminSettings_UnitTestCase.php
+++ b/tests/phpunit/includes/AdminSettings_UnitTestCase.php
@@ -6,6 +6,20 @@
  */
 abstract class AdminSettings_UnitTestCase extends WP_UnitTestCase {
 	/**
+	 * The user ID of an administrator.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * The user ID of an editor.
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
 	 * The Name of the Option.
 	 *
 	 * @var string
@@ -20,7 +34,19 @@ abstract class AdminSettings_UnitTestCase extends WP_UnitTestCase {
 	protected static $options_page = 'aspireupdate-settings';
 
 	/**
-	 * Deletes settings before each test runs.
+	 * Creates administrator and editor users before any tests run.
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$admin_id  = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		self::$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+	}
+
+	/**
+	 * Deletes settings and sets the current user before each test runs.
 	 *
 	 * @return void
 	 */
@@ -28,5 +54,6 @@ abstract class AdminSettings_UnitTestCase extends WP_UnitTestCase {
 		parent::set_up();
 
 		delete_site_option( self::$option_name );
+		wp_set_current_user( self::$admin_id );
 	}
 }

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_AdminNoticesTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_AdminNoticesTest.php
@@ -12,6 +12,29 @@
  */
 class AdminSettings_AdminNoticesTest extends AdminSettings_UnitTestCase {
 	/**
+	 * Test that the reset notice is not output when the user does not have the required capability.
+	 */
+	public function test_should_not_output_reset_notice_when_the_user_does_not_have_the_required_capability() {
+		wp_set_current_user( self::$editor_id );
+
+		$this->assertFalse(
+			current_user_can( is_multisite() ? 'manage_network_options' : 'manage_options' ),
+			'The user has the required capability.'
+		);
+
+		update_site_option( 'aspireupdate-reset', 'true' );
+		$_GET['reset-success']       = 'success';
+		$_GET['reset-success-nonce'] = wp_create_nonce( 'aspireupdate-reset-success-nonce' );
+
+		$admin_settings = new \AspireUpdate\Admin_Settings();
+		$actual         = get_echo( [ $admin_settings, 'admin_notices' ] );
+
+		unset( $_GET['reset-success'], $_GET['reset-success-nonce'] );
+
+		$this->assertEmpty( $actual );
+	}
+
+	/**
 	 * Test that the reset notice is not output when the 'aspireupdate-reset' option is not set to (string) "true".
 	 */
 	public function test_should_not_output_reset_notice_when_aspireupdatereset_option_is_not_set_to_true() {
@@ -104,6 +127,10 @@ class AdminSettings_AdminNoticesTest extends AdminSettings_UnitTestCase {
 		$_GET['reset-success']       = 'success';
 		$_GET['reset-success-nonce'] = wp_create_nonce( 'aspireupdate-reset-success-nonce' );
 
+		if ( is_multisite() ) {
+			grant_super_admin( wp_get_current_user()->ID );
+		}
+
 		$admin_settings = new \AspireUpdate\Admin_Settings();
 		$actual         = get_echo( [ $admin_settings, 'admin_notices' ] );
 
@@ -122,6 +149,10 @@ class AdminSettings_AdminNoticesTest extends AdminSettings_UnitTestCase {
 		update_site_option( 'aspireupdate-reset', 'true' );
 		$_GET['reset-success']       = 'success';
 		$_GET['reset-success-nonce'] = wp_create_nonce( 'aspireupdate-reset-success-nonce' );
+
+		if ( is_multisite() ) {
+			grant_super_admin( wp_get_current_user()->ID );
+		}
 
 		$admin_settings = new \AspireUpdate\Admin_Settings();
 		get_echo( [ $admin_settings, 'admin_notices' ] );
@@ -162,6 +193,10 @@ class AdminSettings_AdminNoticesTest extends AdminSettings_UnitTestCase {
 	 */
 	public function test_should_output_saved_notice() {
 		$_GET['settings-updated-wpnonce'] = wp_create_nonce( 'aspireupdate-settings-updated-nonce' );
+
+		if ( is_multisite() ) {
+			grant_super_admin( wp_get_current_user()->ID );
+		}
 
 		$admin_settings = new \AspireUpdate\Admin_Settings();
 		$actual         = get_echo( [ $admin_settings, 'admin_notices' ] );

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_RegisterAdminMenuTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_RegisterAdminMenuTest.php
@@ -17,21 +17,6 @@
  * @covers \AspireUpdate\Admin_Settings::register_admin_menu
  */
 class AdminSettings_RegisterAdminMenuTest extends AdminSettings_UnitTestCase {
-	/**
-	 * The user ID of an administrator.
-	 *
-	 * @var int
-	 */
-	private static $admin_id;
-
-	/**
-	 * Create an administrator before any tests run.
-	 *
-	 * @return void
-	 */
-	public static function set_up_before_class() {
-		self::$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
-	}
 
 	/**
 	 * Test that menu is not registered when AP_REMOVE_UI is enabled.
@@ -41,7 +26,6 @@ class AdminSettings_RegisterAdminMenuTest extends AdminSettings_UnitTestCase {
 		$original_submenu = $submenu;
 
 		define( 'AP_REMOVE_UI', true );
-		wp_set_current_user( self::$admin_id );
 
 		$admin_settings = new \AspireUpdate\Admin_Settings();
 		$admin_settings->register_admin_menu();
@@ -71,7 +55,6 @@ class AdminSettings_RegisterAdminMenuTest extends AdminSettings_UnitTestCase {
 		global $submenu;
 
 		define( 'AP_REMOVE_UI', false );
-		wp_set_current_user( self::$admin_id );
 		grant_super_admin( self::$admin_id );
 
 		$admin_settings = new \AspireUpdate\Admin_Settings();

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_RegisterAdminMenuTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_RegisterAdminMenuTest.php
@@ -41,6 +41,7 @@ class AdminSettings_RegisterAdminMenuTest extends AdminSettings_UnitTestCase {
 		$original_submenu = $submenu;
 
 		define( 'AP_REMOVE_UI', false );
+		wp_set_current_user( self::$editor_id );
 
 		$admin_settings = new \AspireUpdate\Admin_Settings();
 		$admin_settings->register_admin_menu();

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_ResetSettingsTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_ResetSettingsTest.php
@@ -12,6 +12,28 @@
  */
 class AdminSettings_ResetSettingsTest extends AdminSettings_UnitTestCase {
 	/**
+	 * Test that settings are not reset when the user does not have the required capability.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_not_reset_settings_when_the_user_does_not_have_the_required_capability() {
+		wp_set_current_user( self::$editor_id );
+		$_GET['reset']       = 'reset';
+		$_GET['reset-nonce'] = wp_create_nonce( 'aspireupdate-reset-nonce' );
+
+		$settings = [ 'api_host' => 'the.option.value' ];
+		update_site_option( self::$option_name, $settings );
+
+		$admin_settings = new \AspireUpdate\Admin_Settings();
+		$admin_settings->reset_settings();
+
+		unset( $_GET['reset'], $_GET['reset-nonce'] );
+
+		$this->assertSame( $settings, get_site_option( self::$option_name ) );
+	}
+
+	/**
 	 * Test that settings are not reset when $_GET['reset'] is not set.
 	 */
 	public function test_should_not_reset_settings_when_get_reset_is_not_set() {
@@ -146,6 +168,10 @@ class AdminSettings_ResetSettingsTest extends AdminSettings_UnitTestCase {
 		$_GET['reset']       = 'reset';
 		$_GET['reset-nonce'] = wp_create_nonce( 'aspireupdate-reset-nonce' );
 
+		if ( is_multisite() ) {
+			grant_super_admin( wp_get_current_user()->ID );
+		}
+
 		$settings = [ 'api_host' => 'the.option.value' ];
 		update_site_option( self::$option_name, $settings );
 
@@ -166,6 +192,10 @@ class AdminSettings_ResetSettingsTest extends AdminSettings_UnitTestCase {
 	public function test_should_redirect_when_reset_requirements_are_met() {
 		$_GET['reset']       = 'reset';
 		$_GET['reset-nonce'] = wp_create_nonce( 'aspireupdate-reset-nonce' );
+
+		if ( is_multisite() ) {
+			grant_super_admin( wp_get_current_user()->ID );
+		}
 
 		$settings = [ 'api_host' => 'the.option.value' ];
 		update_site_option( self::$option_name, $settings );

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_UpdateSettingsTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_UpdateSettingsTest.php
@@ -12,6 +12,29 @@
  */
 class AdminSettings_UpdateSettingsTest extends AdminSettings_UnitTestCase {
 	/**
+	 * Test that settings are not updated when the user does not have the required capability.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_not_update_settings_when_the_user_does_not_have_the_required_capability() {
+		wp_set_current_user( self::$editor_id );
+		$_POST['_wpnonce']              = wp_create_nonce( self::$options_page );
+		$_POST['option_page']           = self::$option_name;
+		$_POST['aspireupdate_settings'] = [ 'api_host' => 'the.option.value' ];
+
+		$settings = get_site_option( self::$option_name, false );
+
+		$admin_settings = new AspireUpdate\Admin_Settings();
+		$admin_settings->update_settings();
+
+		$this->assertSame(
+			$settings,
+			get_site_option( self::$option_name, false )
+		);
+	}
+
+	/**
 	 * Test that settings are not updated when $_POST['_wpnonce'] is not set.
 	 */
 	public function test_should_not_update_settings_when_post_wpnonce_is_not_set() {
@@ -202,6 +225,10 @@ class AdminSettings_UpdateSettingsTest extends AdminSettings_UnitTestCase {
 		$_POST['option_page']           = self::$option_name;
 		$_POST['aspireupdate_settings'] = [ 'api_host' => 'the.option.value' ];
 
+		if ( is_multisite() ) {
+			grant_super_admin( wp_get_current_user()->ID );
+		}
+
 		delete_site_option( self::$option_name );
 
 		$admin_settings = new AspireUpdate\Admin_Settings();
@@ -237,6 +264,10 @@ class AdminSettings_UpdateSettingsTest extends AdminSettings_UnitTestCase {
 		$_POST['_wpnonce']              = wp_create_nonce( self::$options_page );
 		$_POST['option_page']           = self::$option_name;
 		$_POST['aspireupdate_settings'] = [ 'api_host' => 'the.option.value' ];
+
+		if ( is_multisite() ) {
+			grant_super_admin( wp_get_current_user()->ID );
+		}
 
 		$redirect = new MockAction();
 		add_filter( 'wp_redirect', [ $redirect, 'filter' ] );


### PR DESCRIPTION
# Pull Request

## What changed?

- Added capability checks to the following methods:
  - `Admin_Settings::reset_settings()` - Tests included.
  - `Admin_Settings::admin_notices()` - Tests included.
  - `Admin_Settings::update_settings()` - Tests included.
  - `Controller::clear_log()` - Tests not possible as the underlying code terminates execution.
  - `Controller::read_log()` - Tests not possible as the underlying code terminates execution.
- Updated `AdminSettings_UnitTestCase` to:
  - add `$admin_id` and `$editor_id` properties for use in AdminSettings tests.
  - set the user to `$admin_id` by default. (Most tests need this).
- Updated existing tests to:
  - set the user to `$editor_id` where necessary (only a few tests need this).
  - grant super admin where necessary (only a few tests need this).

## Why did it change?

To harden the plugin.

## Did you fix any specific issues?

Fixes #277

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

