### PR TITLE
Test fixes and improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,35 @@
         "test:multisite": [
             "Composer\\Config::disableProcessTimeout",
             "@php ./vendor/phpunit/phpunit/phpunit -c tests/phpunit/multisite.xml"
+        ],
+        "coverage:merge": [
+            "Composer\\Config::disableProcessTimeout",
+            "@putenv XDEBUG_MODE=coverage",
+            "@php ./vendor/bin/phpunit-merger coverage tests/phpunit/coverage/php --html tests/phpunit/coverage/html/full tests/phpunit/cache/full-cache.xml"
+        ],
+        "coverage:single": [
+            "Composer\\Config::disableProcessTimeout",
+            "@putenv XDEBUG_MODE=off",
+            "@putenv WP_TESTS_SKIP_INSTALL=0",
+            "@test --filter prime_test_suite",
+            "@putenv XDEBUG_MODE=coverage",
+            "@putenv WP_TESTS_SKIP_INSTALL=1",
+            "@test"
+        ],
+        "coverage:multisite": [
+            "Composer\\Config::disableProcessTimeout",
+            "@putenv XDEBUG_MODE=off",
+            "@putenv WP_TESTS_SKIP_INSTALL=0",
+            "@test:multisite --filter prime_test_suite",
+            "@putenv XDEBUG_MODE=coverage",
+            "@putenv WP_TESTS_SKIP_INSTALL=1",
+            "@test:multisite"
+        ],
+        "coverage:full": [
+            "Composer\\Config::disableProcessTimeout",
+            "@coverage:single",
+            "@coverage:multisite",
+            "@coverage:merge"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "3.10.3",
         "wp-coding-standards/wpcs": "~3.1.0",
-        "yoast/phpunit-polyfills": "^1.1.0"
+        "yoast/phpunit-polyfills": "^1.1.0",
+        "nimut/phpunit-merger": "^2.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         ],
         "test:multisite": [
             "Composer\\Config::disableProcessTimeout",
-            "@php ./vendor/phpunit/phpunit/phpunit -c tests/multisite.xml"
-        ]
+            "@php ./vendor/phpunit/phpunit/phpunit -c tests/phpunit/multisite.xml"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d376331f9e6e6c82ad7397106adb6eb",
+    "content-hash": "f401eb18c8a184d86bc2db09420c8b78",
     "packages": [
         {
             "name": "afragen/autoloader",
@@ -367,6 +367,79 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
             },
             "time": "2024-10-08T18:51:32+00:00"
+        },
+        {
+            "name": "nimut/phpunit-merger",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nimut/phpunit-merger.git",
+                "reference": "ae4e968e677bfd3fda68000a9a304ae6965353e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nimut/phpunit-merger/zipball/ae4e968e677bfd3fda68000a9a304ae6965353e6",
+                "reference": "ae4e968e677bfd3fda68000a9a304ae6965353e6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "php": "^8.0",
+                "phpunit/php-code-coverage": "^9.0 || ^10.0",
+                "symfony/console": ">=2.7 <8.0",
+                "symfony/finder": ">=2.7 <8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpspec/prophecy": "^1.0",
+                "phpunit/phpunit": "^9.3 || ^10.0",
+                "symfony/filesystem": ">=2.7 <8.0"
+            },
+            "suggest": {
+                "friendsofphp/php-cs-fixer": "Tool to automatically fix PHP coding standards issues"
+            },
+            "bin": [
+                "bin/phpunit-merger"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nimut\\PhpunitMerger\\": "src/PhpunitMerger/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Nicole Cordes",
+                    "email": "typo3@cordes.co",
+                    "homepage": "https://www.biz-design.biz",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Helmut Hummel",
+                    "email": "info@helhum.io",
+                    "homepage": "https://helhum.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Merge multiple PHPUnit reports into one file",
+            "homepage": "https://github.com/Nimut/phpunit-merger",
+            "keywords": [
+                "TYPO3 CMS",
+                "coverage",
+                "phpunit",
+                "sonarqube"
+            ],
+            "support": {
+                "issues": "https://github.com/Nimut/phpunit-merger/issues",
+                "source": "https://github.com/Nimut/phpunit-merger/tree/2.0.1"
+            },
+            "time": "2024-08-05T08:33:05+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1073,6 +1146,59 @@
                 }
             ],
             "time": "2024-09-19T10:50:18+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2116,6 +2242,718 @@
                 }
             ],
             "time": "2024-09-18T10:38:58+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-11T03:49:26+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v7.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "87a71856f2f56e4100373e92529eed3171695cfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/87a71856f2f56e4100373e92529eed3171695cfb",
+                "reference": "87a71856f2f56e4100373e92529eed3171695cfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-30T19:00:17+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-13T13:31:26+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,7 +30,7 @@
 		</exclude>
 		<report>
 			<text outputFile="php://stdout" showOnlySummary="true"/>
-			<html outputDirectory="./tests/phpunit/coverage"/>
+			<html outputDirectory="./tests/phpunit/coverage/html/single-site"/>
 		</report>
 	</coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,11 +21,12 @@
 	</groups>
 	<coverage includeUncoveredFiles="true" processUncoveredFiles="false" pathCoverage="false" cacheDirectory="./tests/phpunit/cache">
 		<include>
-			<file>./aspire-update.php</file>
 			<directory suffix=".php">./includes</directory>
 		</include>
 		<exclude>
 			<file>./includes/autoload.php</file>
+			<file>./aspire-update.php</file>
+			<directory>./includes/views</directory>
 		</exclude>
 		<report>
 			<text outputFile="php://stdout" showOnlySummary="true"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,7 @@
 			<group>ms-required</group>
 		</exclude>
 	</groups>
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="false" pathCoverage="true" cacheDirectory="./tests/phpunit/cache">
+	<coverage includeUncoveredFiles="true" processUncoveredFiles="false" pathCoverage="false" cacheDirectory="./tests/phpunit/cache">
 		<include>
 			<file>./aspire-update.php</file>
 			<directory suffix=".php">./includes</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,7 @@
 		<report>
 			<text outputFile="php://stdout" showOnlySummary="true"/>
 			<html outputDirectory="./tests/phpunit/coverage/html/single-site"/>
+			<php outputFile="./tests/phpunit/coverage/php/single-site.php"/>
 		</report>
 	</coverage>
 </phpunit>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -46,3 +46,4 @@ require __DIR__ . '/includes/class-ap-fake-filesystem.php';
 // Load unit test abstract classes.
 require __DIR__ . '/includes/AdminSettings_UnitTestCase.php';
 require __DIR__ . '/includes/Debug_UnitTestCase.php';
+require __DIR__ . '/includes/FilesystemDirect_UnitTestCase.php';

--- a/tests/phpunit/includes/FilesystemDirect_UnitTestCase.php
+++ b/tests/phpunit/includes/FilesystemDirect_UnitTestCase.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Abstract base test class for \AspireUpdate\Filesystem_Direct.
+ *
+ * All \AspireUpdate\Filesystem_Direct unit tests should inherit from this class.
+ */
+abstract class FilesystemDirect_UnitTestCase extends WP_UnitTestCase {
+	protected static $test_file = '/tmp/aspireupdate-test-file.txt';
+
+	/**
+	 * Remove the test file should it exist before any tests run.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		if ( file_exists( self::$test_file ) ) {
+			unlink( self::$test_file );
+		}
+	}
+
+	/**
+	 * Remove the test file should it exist after each test runs.
+	 */
+	public function tear_down() {
+		if ( file_exists( self::$test_file ) ) {
+			unlink( self::$test_file );
+		}
+
+		parent::tear_down();
+	}
+}

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -25,7 +25,7 @@
 			<group>ms-excluded</group>
 		</exclude>
 	</groups>
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="false" pathCoverage="true" cacheDirectory="./cache">
+	<coverage includeUncoveredFiles="true" processUncoveredFiles="false" pathCoverage="false" cacheDirectory="./cache">
 		<include>
 			<directory suffix=".php">../../includes</directory>
 		</include>

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -36,7 +36,7 @@
 		</exclude>
 		<report>
 			<text outputFile="php://stdout" showOnlySummary="true"/>
-			<html outputDirectory="./coverage"/>
+			<html outputDirectory="./coverage/html/multisite"/>
 		</report>
 	</coverage>
 </phpunit>

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -31,6 +31,8 @@
 		</include>
 		<exclude>
 			<file>../../includes/autoload.php</file>
+			<file>../../aspire-update.php</file>
+			<directory>../../includes/views</directory>
 		</exclude>
 		<report>
 			<text outputFile="php://stdout" showOnlySummary="true"/>

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -37,6 +37,7 @@
 		<report>
 			<text outputFile="php://stdout" showOnlySummary="true"/>
 			<html outputDirectory="./coverage/html/multisite"/>
+			<php outputFile="./coverage/php/multisite.php"/>
 		</report>
 	</coverage>
 </phpunit>

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_ConstructTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_ConstructTest.php
@@ -16,8 +16,8 @@ class APIRewrite_ConstructTest extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_hooks_and_methods
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_hooks( $hook, $method ) {
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'debug', false, '' );

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_ConstructTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_ConstructTest.php
@@ -41,7 +41,7 @@ class AdminSettings_ConstructTest extends AdminSettings_UnitTestCase {
 			],
 			'admin_init -> update_settings'   => [
 				'hook'   => 'admin_init',
-				'method' => 'register_settings',
+				'method' => 'update_settings',
 			],
 			'admin_enqueue_scripts -> admin_enqueue_scripts' => [
 				'hook'   => 'admin_enqueue_scripts',

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_ConstructTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_ConstructTest.php
@@ -16,8 +16,8 @@ class AdminSettings_ConstructTest extends AdminSettings_UnitTestCase {
 	 *
 	 * @dataProvider data_hooks_and_methods
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_hooks( $hook, $method ) {
 		$admin_settings = new AspireUpdate\Admin_Settings();
@@ -57,8 +57,8 @@ class AdminSettings_ConstructTest extends AdminSettings_UnitTestCase {
 	 *
 	 * @group ms-excluded
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_single_site_hooks_in_single_site( $hook, $method ) {
 		$admin_settings = new AspireUpdate\Admin_Settings();
@@ -90,8 +90,8 @@ class AdminSettings_ConstructTest extends AdminSettings_UnitTestCase {
 	 *
 	 * @group ms-required
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_multisite_hooks_in_multisite( $hook, $method ) {
 		$admin_settings = new AspireUpdate\Admin_Settings();

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_GetSettingTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_GetSettingTest.php
@@ -81,7 +81,7 @@ class AdminSettings_GetSettingTest extends AdminSettings_UnitTestCase {
 	}
 
 	/**
-	 * Data provider with different valeus for options and constants.
+	 * Data provider with different values for options and constants.
 	 *
 	 * @return array[]
 	 */

--- a/tests/phpunit/tests/Branding/Branding_AdminEnqueueScriptsTest.php
+++ b/tests/phpunit/tests/Branding/Branding_AdminEnqueueScriptsTest.php
@@ -18,6 +18,8 @@ class Branding_AdminEnqueueScriptsTest extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		wp_dequeue_style( 'aspire_update_settings_css' );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/tests/Branding/Branding_ConstructTest.php
+++ b/tests/phpunit/tests/Branding/Branding_ConstructTest.php
@@ -21,8 +21,8 @@ class Branding_ConstructTest extends WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_hooks_in_single_site( $hook, $method ) {
 		define( 'AP_ENABLE', true );
@@ -41,8 +41,8 @@ class Branding_ConstructTest extends WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_not_add_hooks_in_single_site( $hook, $method ) {
 		define( 'AP_ENABLE', false );
@@ -79,8 +79,8 @@ class Branding_ConstructTest extends WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_hooks_in_multisite( $hook, $method ) {
 		define( 'AP_ENABLE', true );
@@ -99,8 +99,8 @@ class Branding_ConstructTest extends WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_not_add_hooks_in_multisite( $hook, $method ) {
 		define( 'AP_ENABLE', false );

--- a/tests/phpunit/tests/Controller/Controller_ConstructTest.php
+++ b/tests/phpunit/tests/Controller/Controller_ConstructTest.php
@@ -16,8 +16,8 @@ class Controller_ConstructTest extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_hooks_and_methods
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_hooks( $hook, $method ) {
 		$controller = new AspireUpdate\Controller();

--- a/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_GetContentsArrayTest.php
+++ b/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_GetContentsArrayTest.php
@@ -20,6 +20,8 @@ class FilesystemDirect_GetContentsArrayTest extends WP_UnitTestCase {
 	 * Remove the test file should it exist before any tests run.
 	 */
 	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
 		if ( file_exists( self::$test_file ) ) {
 			unlink( self::$test_file );
 		}
@@ -32,6 +34,8 @@ class FilesystemDirect_GetContentsArrayTest extends WP_UnitTestCase {
 		if ( file_exists( self::$test_file ) ) {
 			unlink( self::$test_file );
 		}
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_GetContentsArrayTest.php
+++ b/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_GetContentsArrayTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class GetContentsArrayTest
+ * Class FilesystemDirect_GetContentsArrayTest
  *
  * @package AspireUpdate
  */
@@ -13,7 +13,7 @@
  *
  * @covers \AspireUpdate\Filesystem_Direct::get_contents_array
  */
-class GetContentsArrayTest extends WP_UnitTestCase {
+class FilesystemDirect_GetContentsArrayTest extends WP_UnitTestCase {
 	private static $test_file = '/tmp/aspireupdate-getcontentsarray-test-file.txt';
 
 	/**

--- a/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_GetContentsArrayTest.php
+++ b/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_GetContentsArrayTest.php
@@ -13,31 +13,7 @@
  *
  * @covers \AspireUpdate\Filesystem_Direct::get_contents_array
  */
-class FilesystemDirect_GetContentsArrayTest extends WP_UnitTestCase {
-	private static $test_file = '/tmp/aspireupdate-getcontentsarray-test-file.txt';
-
-	/**
-	 * Remove the test file should it exist before any tests run.
-	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		if ( file_exists( self::$test_file ) ) {
-			unlink( self::$test_file );
-		}
-	}
-
-	/**
-	 * Remove the test file should it exist after each test runs.
-	 */
-	public function tear_down() {
-		if ( file_exists( self::$test_file ) ) {
-			unlink( self::$test_file );
-		}
-
-		parent::tear_down();
-	}
-
+class FilesystemDirect_GetContentsArrayTest extends FilesystemDirect_UnitTestCase {
 	/**
 	 * Test that false is returned when the file does not exist.
 	 */

--- a/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_PutContentsTest.php
+++ b/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_PutContentsTest.php
@@ -13,31 +13,7 @@
  *
  * @covers \AspireUpdate\Filesystem_Direct::put_contents
  */
-class FilesystemDirect_PutContentsTest extends WP_UnitTestCase {
-	private static $test_file = '/tmp/aspireupdate-putcontents-test-file.txt';
-
-	/**
-	 * Remove the test file should it exist before any tests run.
-	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		if ( file_exists( self::$test_file ) ) {
-			unlink( self::$test_file );
-		}
-	}
-
-	/**
-	 * Remove the test file should it exist after each test runs.
-	 */
-	public function tear_down() {
-		if ( file_exists( self::$test_file ) ) {
-			unlink( self::$test_file );
-		}
-
-		parent::tear_down();
-	}
-
+class FilesystemDirect_PutContentsTest extends FilesystemDirect_UnitTestCase {
 	/**
 	 * Test that false is returned when an invalid write mode is provided.
 	 */

--- a/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_PutContentsTest.php
+++ b/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_PutContentsTest.php
@@ -20,6 +20,8 @@ class FilesystemDirect_PutContentsTest extends WP_UnitTestCase {
 	 * Remove the test file should it exist before any tests run.
 	 */
 	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
 		if ( file_exists( self::$test_file ) ) {
 			unlink( self::$test_file );
 		}
@@ -32,6 +34,8 @@ class FilesystemDirect_PutContentsTest extends WP_UnitTestCase {
 		if ( file_exists( self::$test_file ) ) {
 			unlink( self::$test_file );
 		}
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_PutContentsTest.php
+++ b/tests/phpunit/tests/FilesystemDirect/FilesystemDirect_PutContentsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class PutContentsTest
+ * Class FilesystemDirect_PutContentsTest
  *
  * @package AspireUpdate
  */
@@ -13,7 +13,7 @@
  *
  * @covers \AspireUpdate\Filesystem_Direct::put_contents
  */
-class PutContentsTest extends WP_UnitTestCase {
+class FilesystemDirect_PutContentsTest extends WP_UnitTestCase {
 	private static $test_file = '/tmp/aspireupdate-putcontents-test-file.txt';
 
 	/**

--- a/tests/phpunit/tests/PluginsScreens/PluginsScreens_ConstructTest.php
+++ b/tests/phpunit/tests/PluginsScreens/PluginsScreens_ConstructTest.php
@@ -22,8 +22,8 @@ class PluginsScreens_ConstructTest extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_single_site_hooks_and_methods
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_hooks( $hook, $method ) {
 		define( 'AP_ENABLE', true );
@@ -37,8 +37,8 @@ class PluginsScreens_ConstructTest extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_single_site_hooks_and_methods
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_not_add_hooks( $hook, $method ) {
 		define( 'AP_ENABLE', false );

--- a/tests/phpunit/tests/ThemesScreens/ThemesScreens_AdminEnqueueScriptsTest.php
+++ b/tests/phpunit/tests/ThemesScreens/ThemesScreens_AdminEnqueueScriptsTest.php
@@ -18,6 +18,8 @@ class ThemesScreens_AdminEnqueueScriptsTest extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		wp_dequeue_style( 'aspire_update_themes_screens_css' );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/tests/ThemesScreens/ThemesScreens_ConstructTest.php
+++ b/tests/phpunit/tests/ThemesScreens/ThemesScreens_ConstructTest.php
@@ -23,8 +23,8 @@ class ThemesScreens_ConstructTest extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_hooks_and_methods
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_hooks( $hook, $method ) {
 		define( 'AP_ENABLE', true );
@@ -38,8 +38,8 @@ class ThemesScreens_ConstructTest extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_hooks_and_methods
 	 *
-	 * @string $hook   The hook's name.
-	 * @string $method The method to hook.
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
 	 */
 	public function test_should_not_add_hooks( $hook, $method ) {
 		define( 'AP_ENABLE', false );


### PR DESCRIPTION
# Pull Request

## What changed?

- Changed mistaken `@string` annotations to `@param string` in some test docblocks.
- Prefixed the `Filesystem_Direct` test classes and files with `FilesystemDirect_`.
- Fixed a minor typo in one of the test docblocks.
- Fixed the `AdminSettings_ConstructTest::data_hooks_and_methods()` data provider dataset `admin_init -> update_settings` to pass `update_settings` as intended.
- Added calls to parent `set_up_before_class()`, `set_up()` or `tear_down()` methods in several test classes.
- Abstracted the shared fixtures for the `Filesystem_Direct` tests to `FilesystemDirect_UnitTestCase`.
- Fixed the path to the multisite configuration file in `composer.json`.
- Disabled path coverage by default.
- Excluded untested files from coverage reports.
- Configured dedicated site type coverage directories for targeted viewing.
  - `tests/phpunit/coverage/html/single-site`
  - `tests/phpunit/coverage/html/multisite`
- Configured a dedicated site type coverage PHP file to enable merging the reports.
  - `tests/phpunit/coverage/php/single-site.php`
  - `tests/phpunit/coverage/php/multisite.php`
- Added `namut/phpunit-merger` for merging coverage reports.
- Added composer scripts for coverage.
  - `composer coverage:single`
    - Run a coverage report for single-site.
    - View at `http://.../tests/phpunit/coverage/html/single-site`.
  - `composer coverage:multisite`
    - Run a coverage report for multisite.
    - View at `http://.../tests/phpunit/coverage/html/multisite`.
  - `composer coverage:full`
    - Run both reports and merge the results.
    - View at  `View at `http://.../tests/phpunit/coverage/html/merged`.
  - `composer coverage:merge` - Merge existing coverage reports to `tests/phpunit/coverage/html/merged`.

## Why did it change?

To improve the test suite and coverage configuration.

## Did you fix any specific issues?

Fixes #281 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

