### PR TITLE
Add Accept JSON header if the request is not for downloading a file.

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -85,7 +85,7 @@ class API_Rewrite {
 	private function add_accept_json_header( $args, $url ) {
 		$path = wp_parse_url( $url, PHP_URL_PATH );
 		// Check if the URL points to a .php file or has no extension.
-		if ( preg_match( '/\/[^\/]+\.(php)$/', $path ) || preg_match( '/\/[^\/]+\/$/', $path ) ) {
+		if ( preg_match( '#/[^/]+(\.php|/)$#', $path ) ) {
 			Debug::log_string( __( 'Accept JSON Header added for API calls.', 'aspireupdate' ) );
 			if ( ! isset( $args['headers'] ) ) {
 				$args['headers'] = [];

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -76,17 +76,16 @@ class API_Rewrite {
 	}
 
 	/**
-	 * Add Accept JSON header if the request is not for downloading a file.
+	 * Add Accept JSON header if the request is not for a file asset.
 	 *
 	 * @param array $args The HTTP request arguments.
 	 *
 	 * @return array $args The modified HTTP request arguments.
 	 */
 	private function add_accept_json_header( $args, $url ) {
-		$file_extensions = [ 'zip', 'tar', 'gz', 'rar' ];
-		$path            = wp_parse_url( $url, PHP_URL_PATH );
-		$extension       = wp_check_filetype( $path )['ext'];
-		if ( ! $extension || ! in_array( strtolower( $extension ), $file_extensions, true ) ) {
+		$path = wp_parse_url( $url, PHP_URL_PATH );
+		// Check if the URL points to a .php file or has no extension.
+		if ( preg_match( '/\/[^\/]+\.(php)$/', $path ) || preg_match( '/\/[^\/]+\/$/', $path ) ) {
 			Debug::log_string( __( 'Accept JSON Header added for API calls.', 'aspireupdate' ) );
 			if ( ! isset( $args['headers'] ) ) {
 				$args['headers'] = [];

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -58,6 +58,57 @@ class API_Rewrite {
 	}
 
 	/**
+	 * Add Authorization Header if API Key found.
+	 *
+	 * @param array $args The HTTP request arguments.
+	 *
+	 * @return array $args The modified HTTP request arguments.
+	 */
+	private function add_authorization_header( $args ) {
+		if ( '' !== $this->api_key ) {
+			Debug::log_string( __( 'API Key Authorization header added.', 'aspireupdate' ) );
+			if ( ! isset( $args['headers'] ) ) {
+				$args['headers'] = [];
+			}
+			$args['headers']['Authorization'] = 'Bearer ' . $this->api_key;
+		}
+		return $args;
+	}
+
+	/**
+	 * Add Accept JSON header if the request is not for downloading a file.
+	 *
+	 * @param array $args The HTTP request arguments.
+	 *
+	 * @return array $args The modified HTTP request arguments.
+	 */
+	private function add_accept_json_header( $args, $url ) {
+		$file_extensions = [ 'zip', 'tar', 'gz', 'rar' ];
+		$path            = wp_parse_url( $url, PHP_URL_PATH );
+		$extension       = wp_check_filetype( $path )['ext'];
+		if ( ! $extension || ! in_array( strtolower( $extension ), $file_extensions, true ) ) {
+			Debug::log_string( __( 'Accept JSON Header added for API calls.', 'aspireupdate' ) );
+			if ( ! isset( $args['headers'] ) ) {
+				$args['headers'] = [];
+			}
+			$args['headers']['Accept'] = 'application/json';
+		}
+		return $args;
+	}
+
+	/**
+	 * Adding cache buster parameter for AC beta test.  Will remove this after Beta.
+	 *
+	 * @param string $url The URL.
+	 *
+	 * @return string $url The updated URL.
+	 */
+	private function add_cache_buster( $url ) {
+		Debug::log_string( __( 'Cache Buster Added to URL', 'aspireupdate' ) );
+		return add_query_arg( 'cache_buster', time(), $url );
+	}
+
+	/**
 	 * Rewrite the API End points.
 	 *
 	 * @param mixed  $response The response for the request.
@@ -82,19 +133,11 @@ class API_Rewrite {
 						$parsed_args['sslverify'] = false;
 					}
 
-					if ( '' !== $this->api_key ) {
-						Debug::log_string( __( 'API Key Authorization header added.', 'aspireupdate' ) );
-						$parsed_args['headers']['Authorization'] = 'Bearer ' . $this->api_key;
-					}
+					$parsed_args = $this->add_authorization_header( $parsed_args );
+					$parsed_args = $this->add_accept_json_header( $parsed_args, $url );
+					$url         = $this->add_cache_buster( $url );
 
 					$updated_url = str_replace( $this->default_host, $this->redirected_host, $url );
-
-					/**
-					 * Adding cache buster parameter for AC beta test.  Will remove this after Beta.
-					 */
-					Debug::log_string( __( 'Cache Buster Added to URL', 'aspireupdate' ) );
-					$updated_url = add_query_arg( 'cache_buster', time(), $updated_url );
-
 					Debug::log_string( __( 'API Rerouted to: ', 'aspireupdate' ) . $updated_url );
 
 					Debug::log_request( $parsed_args );

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -93,6 +93,8 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that the default host is replaced with the redirected host.
+	 *
+	 * @covers \AspireUpdate\API_Rewrite::add_cache_buster
 	 */
 	public function test_should_replace_default_host_with_redirected_host() {
 		$actual = '';
@@ -115,6 +117,8 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that the API Key is added to the Authorization header.
+	 *
+	 * @covers \AspireUpdate\API_Rewrite::add_authorization_header
 	 */
 	public function test_should_add_api_key_to_authorization_header_when_present() {
 		$actual = [];


### PR DESCRIPTION
# Pull Request

## What changed?

Add Accept JSON header if the request is not for downloading a file.

## Why did it change?

1) Add Accept JSON header if the request is not for downloading a file. 
2) Split the rewrite function for easy test-ability.

## Did you fix any specific issues?

#274 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

