### PR TITLE
288 [Bug]: Change Generate POT workflow to run only on tagging

### DIFF
--- a/.github/workflows/generate-pot-pr.yml
+++ b/.github/workflows/generate-pot-pr.yml
@@ -3,9 +3,8 @@ name: Generate POT PR
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
-
+    tags:
+      - "**"
 jobs:
   generate-pot:
     name: Generate POT PR


### PR DESCRIPTION
# Pull Request

## What changed?

Change workflow to run on tagging, not on branch push to `main`.
Fixes #288 

## Why did it change?

Too many runs of the workflow when not necessary. Now we will only run when a release is tagged.

## Did you fix any specific issues?

n/a

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

