### PR TITLE
build: update to afragen/autoloader 3.0.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,16 +12,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/afragen/autoloader.git",
-                "reference": "ab30ab542c48fe3ecd26c3bda28fef544f04b401"
+                "reference": "f79332a25eadecb53b397b84d0a5220cbbc4b457"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/afragen/autoloader/zipball/ab30ab542c48fe3ecd26c3bda28fef544f04b401",
-                "reference": "ab30ab542c48fe3ecd26c3bda28fef544f04b401",
+                "url": "https://api.github.com/repos/afragen/autoloader/zipball/f79332a25eadecb53b397b84d0a5220cbbc4b457",
+                "reference": "f79332a25eadecb53b397b84d0a5220cbbc4b457",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.1"
             },
             "default-branch": true,
             "type": "library",
@@ -43,9 +43,9 @@
             ],
             "support": {
                 "issues": "https://github.com/afragen/autoloader/issues",
-                "source": "https://github.com/afragen/autoloader/tree/3.0.0"
+                "source": "https://github.com/afragen/autoloader/tree/3.0.1"
             },
-            "time": "2024-11-27T02:42:42+00:00"
+            "time": "2025-02-19T18:41:01+00:00"
         },
         {
             "name": "afragen/translations-updater",
@@ -252,16 +252,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
                 "shasum": ""
             },
             "require": {
@@ -300,7 +300,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
             },
             "funding": [
                 {
@@ -308,20 +308,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-02-12T12:17:51+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.3.1",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
-                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
@@ -364,9 +364,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
-            "time": "2024-10-08T18:51:32+00:00"
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "nimut/phpunit-merger",
@@ -1046,16 +1046,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.21",
+            "version": "9.6.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
                 "shasum": ""
             },
             "require": {
@@ -1066,7 +1066,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.0",
+                "myclabs/deep-copy": "^1.12.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -1129,7 +1129,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
             },
             "funding": [
                 {
@@ -1145,7 +1145,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T10:50:18+00:00"
+            "time": "2024-12-05T13:48:26+00:00"
         },
         {
             "name": "psr/container",
@@ -3073,16 +3073,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.1.2",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "e9c8413de4c8ae03d2923a44f17d0d7dad1b96be"
+                "reference": "e6faedf5e34cea4438e341f660e2f719760c531d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/e9c8413de4c8ae03d2923a44f17d0d7dad1b96be",
-                "reference": "e9c8413de4c8ae03d2923a44f17d0d7dad1b96be",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/e6faedf5e34cea4438e341f660e2f719760c531d",
+                "reference": "e6faedf5e34cea4438e341f660e2f719760c531d",
                 "shasum": ""
             },
             "require": {
@@ -3097,7 +3097,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -3132,7 +3132,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2024-09-06T22:03:10+00:00"
+            "time": "2025-02-09T18:13:44+00:00"
         }
     ],
     "aliases": [],

--- a/vendor/afragen/autoloader/Autoloader.php
+++ b/vendor/afragen/autoloader/Autoloader.php
@@ -55,7 +55,7 @@ if ( ! class_exists( 'Fragen\\Autoloader' ) ) {
 		 * @param array|null $static_map Array of classes that deviate from convention.
 		 *                               Defaults to null.
 		 */
-		public function __construct( array $roots, array $static_map = null ) {
+		public function __construct( array $roots, ?array $static_map = null ) {
 			$this->roots = $roots;
 			if ( null !== $static_map ) {
 				$this->map = $static_map;

--- a/vendor/afragen/autoloader/CHANGES.md
+++ b/vendor/afragen/autoloader/CHANGES.md
@@ -1,3 +1,6 @@
+#### 3.0.1 / 2025-20-19
+* fix PHP8.4 use explicit nullable type from PHP7.1
+
 #### 3.0.0
 * refactor as composer library, though likely better to just use composer's autoloader
 

--- a/vendor/afragen/autoloader/composer.json
+++ b/vendor/afragen/autoloader/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "afragen/autoloader",
     "description": "PSR-4 style autoloader and classmap loader.",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "type": "library",
     "keywords": [
         "autoload"
@@ -23,6 +23,6 @@
     ],
     "prefer-stable": true,
     "require": {
-        "php": ">=5.6"
+        "php": ">=7.1"
     }
 }


### PR DESCRIPTION
# Pull Request

## What changed?

Bumps afragen/autoloader dependency to 3.0.1.  This silences a minor deprecation warning from php 8.4.

## Why did it change?

Future-proofing.

## Did you fix any specific issues?

none.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

