### PR TITLE
API_Rewrite: Return `WP_Error` object for non-200 responses.

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -152,7 +152,13 @@ class API_Rewrite {
 
 					if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 						$message = wp_remote_retrieve_response_message( $response );
-						Debug::log_string( $message );
+						Debug::log_string(
+							sprintf(
+								/* translators: %s: The response message. */
+								__( 'Request Failed: %s', 'aspireupdate' ),
+								$message
+							)
+						);
 						return new \WP_Error( 'failed_request', $message );
 					}
 

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -150,6 +150,13 @@ class API_Rewrite {
 
 					Debug::log_response( $response );
 
+					if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+						return new \WP_Error(
+							'failed_request',
+							wp_remote_retrieve_response_message( $response )
+						);
+					}
+
 					return $response;
 
 				}

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -151,10 +151,9 @@ class API_Rewrite {
 					Debug::log_response( $response );
 
 					if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-						return new \WP_Error(
-							'failed_request',
-							wp_remote_retrieve_response_message( $response )
-						);
+						$message = wp_remote_retrieve_response_message( $response );
+						Debug::log_string( $message );
+						return new \WP_Error( 'failed_request', $message );
 					}
 
 					return $response;

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -391,6 +391,44 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a WP_Error object is returned for non-200 HTTP responses.
+	 */
+	public function test_should_return_wp_error_for_non_200_responses() {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'response' => [
+						'code'    => 401,
+						'message' => 'Unauthorized.',
+					],
+				];
+			},
+			10,
+			2
+		);
+
+		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', true, '' );
+		$actual      = $api_rewrite->pre_http_request(
+			[],
+			[],
+			$this->get_default_host() . '/file.php'
+		);
+
+		$this->assertInstanceOf(
+			'WP_Error',
+			$actual,
+			'A WP_Error object was not returned.'
+		);
+
+		$this->assertSame(
+			'failed_request',
+			$actual->get_error_code(),
+			'The wrong error code was returned.'
+		);
+	}
+
+	/**
 	 * Gets the default host.
 	 *
 	 * @return string The default host.


### PR DESCRIPTION
# Pull Request

## What changed?

- A `WP_Error` object is returned when the request performed by `API_Rewrite::pre_http_request()` returns a non-200 HTTP response.
- A PHPUnit test has been added to verify and protect this behaviour going forward.

## Why did it change?

When the API request failed, the failed response was passed to admin pages, causing PHP warnings. This handles the errors as they should be handled.

## Did you fix any specific issues?

Fixes #294 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

