### PR TITLE
Return `WP_Error` for all response codes that aren't `200` or `404`.

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -150,7 +150,8 @@ class API_Rewrite {
 
 					Debug::log_response( $response );
 
-					if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+					$response_code = wp_remote_retrieve_response_code( $response );
+					if ( 200 !== $response_code && 404 !== $response_code ) {
 						$message = wp_remote_retrieve_response_message( $response );
 						Debug::log_string(
 							sprintf(


### PR DESCRIPTION
# Pull Request

## What changed?

- `WP_Error` is now returned for all response codes that aren't `200` or `404`.
- Tests have been added to ensure that `200` and `404` are the only codes that don't return a `WP_Error`.

## Why did it change?

When an installed plugin isn't available at the API, such as a third-party plugin or a custom plugin, a 404 is returned.

This was previously producing an error on the `Plugins -> Installed Plugins` screen, and shouldn't have been.

## Did you fix any specific issues?

Fixes #294 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

