### PR TITLE
Several tidy ups

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -166,8 +166,12 @@ class API_Rewrite {
 
 					Debug::log_response( $response );
 
-					$response_code = wp_remote_retrieve_response_code( $response );
-					if ( 200 !== $response_code && 404 !== $response_code ) {
+					$response_code         = wp_remote_retrieve_response_code( $response );
+					$codes_to_pass_through = [
+						200,
+						404,
+					];
+					if ( ! in_array( $response_code, $codes_to_pass_through, true ) ) {
 						$message = wp_remote_retrieve_response_message( $response );
 						Debug::log_string(
 							sprintf(

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -127,7 +127,7 @@ class API_Rewrite {
 				Debug::log_string( __( 'Default API Found: ', 'aspireupdate' ) . $url );
 
 				if ( false === filter_var( $this->redirected_host, FILTER_VALIDATE_URL ) ) {
-					$error_message = __( 'Your API host is not a valid URL.' );
+					$error_message = __( 'Your API host is not a valid URL.', 'aspireupdate' );
 					Debug::log_string(
 						sprintf(
 							/* translators: %s: The error message. */

--- a/tests/e2e/admin-settings/api_host.spec.ts
+++ b/tests/e2e/admin-settings/api_host.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable, api_host } from '../data/fields';
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] API Host', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);

--- a/tests/e2e/admin-settings/api_host_other.spec.ts
+++ b/tests/e2e/admin-settings/api_host_other.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable, api_host, api_host_other } from '../data/fields'
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] API Host Other', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);
@@ -21,13 +21,13 @@ test.describe('[Admin Settings] [Field] API Host Other', () => {
 
 	test('is visible when API Host is set to Other', async ({ page }) => {
 		await page.check(fieldSelector + enable);
-		await page.selectOption(fieldSelector + api_host, 'other' );
+		await page.selectOption(fieldSelector + api_host, 'other');
 		await expect(page.locator(fieldSelector + api_host_other)).toBeVisible();
 	});
 
 	test('is empty by default', async ({ page }) => {
 		await page.check(fieldSelector + enable);
-		await page.selectOption(fieldSelector + api_host, 'other' );
+		await page.selectOption(fieldSelector + api_host, 'other');
 		await expect(page.locator(fieldSelector + api_host_other)).toBeVisible();
 		await expect(page.locator(fieldSelector + api_host_other)).toHaveValue('');
 	});

--- a/tests/e2e/admin-settings/api_key.spec.ts
+++ b/tests/e2e/admin-settings/api_key.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable, api_key } from '../data/fields';
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] API Key', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);

--- a/tests/e2e/admin-settings/debug_request.spec.ts
+++ b/tests/e2e/admin-settings/debug_request.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable_debug, debug_request } from '../data/fields';
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] Debug Type: Request', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);

--- a/tests/e2e/admin-settings/debug_response.spec.ts
+++ b/tests/e2e/admin-settings/debug_response.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable_debug, debug_response } from '../data/fields';
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] Debug Type: Response', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);

--- a/tests/e2e/admin-settings/debug_string.spec.ts
+++ b/tests/e2e/admin-settings/debug_string.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable_debug, debug_string } from '../data/fields';
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] Debug Type: String', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);

--- a/tests/e2e/admin-settings/disable_ssl.spec.ts
+++ b/tests/e2e/admin-settings/disable_ssl.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable_debug, disable_ssl } from '../data/fields';
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] Disable SSL Verification', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);

--- a/tests/e2e/admin-settings/enable.spec.ts
+++ b/tests/e2e/admin-settings/enable.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable } from '../data/fields';
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] Enable', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);

--- a/tests/e2e/admin-settings/enable_debug.spec.ts
+++ b/tests/e2e/admin-settings/enable_debug.spec.ts
@@ -3,7 +3,7 @@ import { fieldSelector, enable_debug } from '../data/fields';
 import { settings } from '../data/routes';
 
 test.describe('[Admin Settings] [Field] Enable Debug', () => {
-	test.beforeEach(async ( { page }) => {
+	test.beforeEach(async ({ page }) => {
 		const baseURL = test.info().project.use.baseURL;
 		const settingsPage = `${baseURL}/wp-admin/${settings}`;
 		await page.goto(settingsPage);


### PR DESCRIPTION
# Pull Request

## What changed?

- Added missing textdomain to `__()` call in `API_Rewrite::pre_http_request()`.
- Abstracted passthrough response codes to an array.
- Fixed some formatting inconsistencies in E2E test files.

## Why did it change?

- i18n
- Reduced maintenance
- Consistency.

## Did you fix any specific issues?

Fixes #303 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

