### PR TITLE
API_Rewrite: Only filter `'pre_http_request'` when API rewriting is enabled

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -54,7 +54,10 @@ class API_Rewrite {
 		}
 		$this->disable_ssl = $disable_ssl;
 		$this->api_key     = $api_key;
-		add_filter( 'pre_http_request', [ $this, 'pre_http_request' ], 10, 3 );
+
+		if ( Admin_Settings::get_instance()->get_setting( 'enable', false ) ) {
+			add_filter( 'pre_http_request', [ $this, 'pre_http_request' ], 10, 3 );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_ConstructTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_ConstructTest.php
@@ -32,6 +32,26 @@ class APIRewrite_ConstructTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that hooks are not added when API rewriting is disabled.
+	 *
+	 * This test causes constants to be defined.
+	 * It must run in a separate process and must not preserve global state.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @dataProvider data_hooks_and_methods
+	 *
+	 * @param string $hook   The hook's name.
+	 * @param string $method The method to hook.
+	 */
+	public function test_should_not_add_hooks( $hook, $method ) {
+		define( 'AP_ENABLE', false );
+		$api_rewrite = new AspireUpdate\API_Rewrite( 'debug', false, '' );
+		$this->assertFalse( has_action( $hook, [ $api_rewrite, $method ] ) );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array[]

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_ConstructTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_ConstructTest.php
@@ -12,7 +12,13 @@
  */
 class APIRewrite_ConstructTest extends WP_UnitTestCase {
 	/**
-	 * Test that hooks are added.
+	 * Test that hooks are added when API rewriting is enabled.
+	 *
+	 * This test causes constants to be defined.
+	 * It must run in a separate process and must not preserve global state.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 *
 	 * @dataProvider data_hooks_and_methods
 	 *
@@ -20,6 +26,7 @@ class APIRewrite_ConstructTest extends WP_UnitTestCase {
 	 * @param string $method The method to hook.
 	 */
 	public function test_should_add_hooks( $hook, $method ) {
+		define( 'AP_ENABLE', true );
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'debug', false, '' );
 		$this->assertIsInt( has_action( $hook, [ $api_rewrite, $method ] ) );
 	}


### PR DESCRIPTION
# Pull Request

## What changed?

- Added a check to ensure API rewriting is enabled before hooking `'pre_http_request'`.
- Adjusted an existing `API_Rewrite` test to enable API rewriting.
- Added an `API_Rewrite` test to check that the hook is not added when API rewriting is disabled.

## Why did it change?

The filter should only be applied when API rewriting is enabled.

This was causing errors on several screens when API rewriting was disabled.

## Did you fix any specific issues?

Fixes #305

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

