### PR TITLE
Admin_Settings: Various accessibility improvements

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -424,9 +424,10 @@ class Admin_Settings {
 			'aspireupdate-settings',
 			'aspireupdate_settings_section',
 			[
-				'id'   => 'enable',
-				'type' => 'checkbox',
-				'data' => $options,
+				'id'        => 'enable',
+				'type'      => 'checkbox',
+				'data'      => $options,
+				'label_for' => 'aspireupdate-settings-field-enable',
 			]
 		);
 
@@ -441,6 +442,7 @@ class Admin_Settings {
 				'type'        => 'hosts',
 				'data'        => $options,
 				'description' => esc_html__( 'Your new API Host. Ensure that it starts with http:// or https://', 'aspireupdate' ),
+				'label_for'   => 'aspireupdate-settings-field-api_host',
 				'options'     => [
 					[
 						'value'           => 'https://api.aspirecloud.net',
@@ -482,6 +484,7 @@ class Admin_Settings {
 				'type'        => 'api-key',
 				'data'        => $options,
 				'description' => esc_html__( 'Provides an API key for repositories that may require authentication.', 'aspireupdate' ),
+				'label_for'   => 'aspireupdate-settings-field-api_key',
 			]
 		);
 
@@ -507,6 +510,7 @@ class Admin_Settings {
 				'type'        => 'checkbox',
 				'data'        => $options,
 				'description' => esc_html__( 'Enables debug mode for the plugin.', 'aspireupdate' ),
+				'label_for'   => 'aspireupdate-settings-field-enable_debug',
 			]
 		);
 
@@ -541,6 +545,7 @@ class Admin_Settings {
 				'data'        => $options,
 				'class'       => 'advanced-setting',
 				'description' => esc_html__( 'Disables the verification of SSL to allow local testing.', 'aspireupdate' ),
+				'label_for'   => 'aspireupdate-settings-field-disable_ssl_verification',
 			]
 		);
 	}

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -561,37 +561,38 @@ class Admin_Settings {
 	 */
 	public function add_settings_field_callback( $args = [] ) {
 
-		$defaults      = [
+		$defaults       = [
 			'id'          => '',
 			'type'        => 'text',
 			'description' => '',
 			'data'        => [],
 			'options'     => [],
 		];
-		$args          = wp_parse_args( $args, $defaults );
-		$id            = $args['id'];
-		$type          = $args['type'];
-		$description   = $args['description'];
-		$group_options = $args['options'];
-		$options       = $args['data'];
+		$args           = wp_parse_args( $args, $defaults );
+		$id             = $args['id'];
+		$type           = $args['type'];
+		$description    = $args['description'];
+		$group_options  = $args['options'];
+		$options        = $args['data'];
+		$description_id = "{$id}-description";
 
 		echo '<div class="aspireupdate-settings-field-wrapper aspireupdate-settings-field-wrapper-' . esc_attr( $id ) . '">';
 		switch ( $type ) {
 			case 'text':
 				?>
-					<input type="text" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>" class="regular-text" />
+					<input type="text" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>" class="regular-text" aria-describedby="<?php echo esc_attr( $description_id ); ?>" />
 					<?php
 				break;
 
 			case 'textarea':
 				?>
-					<textarea id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" rows="5" cols="50"><?php echo esc_textarea( $options[ $id ] ?? '' ); ?></textarea>
+					<textarea id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" rows="5" cols="50" aria-describedby="<?php echo esc_attr( $description_id ); ?>"><?php echo esc_textarea( $options[ $id ] ?? '' ); ?></textarea>
 					<?php
 				break;
 
 			case 'checkbox':
 				?>
-					<input type="checkbox" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="1" <?php checked( 1, $options[ $id ] ?? 0 ); ?> />
+					<input type="checkbox" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="1" <?php checked( 1, $options[ $id ] ?? 0 ); ?> aria-describedby="<?php echo esc_attr( $description_id ); ?>" />
 					<?php
 				break;
 
@@ -609,7 +610,7 @@ class Admin_Settings {
 
 			case 'api-key':
 				?>
-					<input type="text" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>" class="regular-text" />
+					<input type="text" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>" class="regular-text" aria-describedby="<?php echo esc_attr( $description_id ); ?>" />
 					<input type="button" id="aspireupdate-generate-api-key" value="Generate API Key" title="<?php esc_attr_e( 'Generate API Key', 'aspireupdate' ); ?>" />
 					<p class="error"></p>
 					<?php
@@ -617,7 +618,7 @@ class Admin_Settings {
 
 			case 'hosts':
 				?>
-				<select id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" class="regular-text">
+				<select id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" class="regular-text" aria-describedby="<?php echo esc_attr( $description_id ); ?>">
 					<?php
 					foreach ( $group_options as $group_option ) {
 						?>
@@ -646,7 +647,7 @@ class Admin_Settings {
 				<?php
 				break;
 		}
-		echo '<p class="description">' . esc_html( $description ) . '</p>';
+		echo '<p class="description" id="' . esc_attr( $description_id ) . '">' . esc_html( $description ) . '</p>';
 		echo '</div>';
 	}
 

--- a/includes/views/page-admin-settings.php
+++ b/includes/views/page-admin-settings.php
@@ -15,8 +15,8 @@ $option_group = $args['option_group'] ?? '';
 			<?php wp_nonce_field( 'aspireupdate-settings' ); ?>
 			<?php submit_button( '', 'primary', 'submit', false ); ?>
 			<a href="<?php echo esc_url( $reset_url ); ?>" class="button button-secondary" ><?php esc_html_e( 'Reset', 'aspireupdate' ); ?></a>
-			<a href="javascript:;" id="aspireupdate-button-clearlog" class="button button-secondary button-clearlog" ><?php esc_html_e( 'Clear Log', 'aspireupdate' ); ?></a>
-			<a href="javascript:;" id="aspireupdate-button-viewlog" class="button button-secondary button-viewlog" ><?php esc_html_e( 'View Log', 'aspireupdate' ); ?></a>
+			<button type="button" id="aspireupdate-button-clearlog" class="button button-secondary button-clearlog" ><?php esc_html_e( 'Clear Log', 'aspireupdate' ); ?></button>
+			<button type="button" id="aspireupdate-button-viewlog" class="button button-secondary button-viewlog" ><?php esc_html_e( 'View Log', 'aspireupdate' ); ?></button>
 		</p>
 	</form>
 	<div id="aspireupdate-log-viewer">


### PR DESCRIPTION
# Pull Request

## What changed?

- Added `aria-describedby` to settings elements and a matching `id` attribute to the `.description` element.
- Added the `label_for` argument to `add_settings_field()` calls to ensure the field labels are wrapped in the `<label>` tags.
- Changed `Clear Log` and `View Log` from `a` elements to `button` elements with `type="button"` so they don't trigger a form submit.

## Why did it change?

- To reduce accessibility errors.
- To be more consistent with other settings pages in WordPress.
- **Note**: There are still 3 errors.
  - An error due to `api_host_other` not having a label.
  - A contrast error for the transparent text in the "Generate API Key" button
  - A contrast error for Voltron.

## Did you fix any specific issues?

Fixes #299 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

