### PR TITLE
Move Admin Settings to the Settings menu

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -111,7 +111,7 @@ class Admin_Settings {
 						'reset-success-nonce' => wp_create_nonce( 'aspireupdate-reset-success-nonce' ),
 
 					],
-					network_admin_url( 'index.php?page=aspireupdate-settings' )
+					network_admin_url( $this->options_base . '?page=aspireupdate-settings' )
 				)
 			);
 			! defined( 'AP_RUN_TESTS' ) && exit;
@@ -296,7 +296,7 @@ class Admin_Settings {
 					[
 						'settings-updated-wpnonce' => wp_create_nonce( 'aspireupdate-settings-updated-nonce' ),
 					],
-					network_admin_url( 'index.php?page=aspireupdate-settings' )
+					network_admin_url( $this->options_base . '?page=aspireupdate-settings' )
 				)
 			);
 			! defined( 'AP_RUN_TESTS' ) && exit;
@@ -310,7 +310,7 @@ class Admin_Settings {
 	 * @return array The modified action links.
 	 */
 	public function plugin_action_links( $links ) {
-		$settings_url = network_admin_url( 'index.php?page=aspireupdate-settings' );
+		$settings_url = network_admin_url( $this->options_base . '?page=aspireupdate-settings' );
 		return array_merge(
 			[
 				'settings' => '<a href="' . esc_url( $settings_url ) . '">' . __( 'Settings', 'aspireupdate' ) . '</a>',
@@ -330,7 +330,7 @@ class Admin_Settings {
 		}
 		if ( false === AP_REMOVE_UI ) {
 			add_submenu_page(
-				'index.php',
+				$this->options_base,
 				'AspireUpdate',
 				'AspireUpdate',
 				is_multisite() ? 'manage_network_options' : 'manage_options',
@@ -379,7 +379,7 @@ class Admin_Settings {
 				'reset-nonce' => wp_create_nonce( 'aspireupdate-reset-nonce' ),
 
 			],
-			network_admin_url( 'index.php?page=aspireupdate-settings' )
+			network_admin_url( $this->options_base . '?page=aspireupdate-settings' )
 		);
 		Utilities::include_file(
 			'page-admin-settings.php',

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -41,9 +41,17 @@ class Admin_Settings {
 	private $options = null;
 
 	/**
+	 * The base page for the options.
+	 *
+	 * @var string
+	 */
+	private $options_base;
+
+	/**
 	 * The Constructor.
 	 */
 	public function __construct() {
+		$this->options_base = is_multisite() ? 'settings.php' : 'options-general.php';
 		add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ $this, 'register_admin_menu' ] );
 		add_filter( 'plugin_action_links_aspireupdate/aspire-update.php', [ $this, 'plugin_action_links' ] );
 		add_action( 'admin_init', [ $this, 'reset_settings' ] );

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -347,9 +347,7 @@ class Admin_Settings {
 	 * @return void
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-
-		if ( ! in_array( $hook, [ 'dashboard_page_aspireupdate-settings', 'index_page_aspireupdate-settings' ], true ) ) {
-
+		if ( 'settings_page_aspireupdate-settings' !== $hook ) {
 			return;
 		}
 		wp_enqueue_style( 'aspire_update_settings_css', plugin_dir_url( __DIR__ ) . 'assets/css/aspire-update.css', [], AP_VERSION );

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -356,7 +356,7 @@ class Admin_Settings {
 			'aspire_update_settings_js',
 			'aspireupdate',
 			[
-				'ajax_url'         => network_admin_url( 'admin-ajax.php' ),
+				'ajax_url'         => admin_url( 'admin-ajax.php' ),
 				'nonce'            => wp_create_nonce( 'aspireupdate-ajax' ),
 				'domain'           => Utilities::get_site_domain(),
 				'line_ending'      => PHP_EOL,

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -154,7 +154,6 @@ class Admin_Settings {
 				esc_html__( 'Settings have been reset to default.', 'aspireupdate' ),
 				'success'
 			);
-			settings_errors( $this->option_name );
 			delete_site_option( 'aspireupdate-reset' );
 		}
 
@@ -171,7 +170,6 @@ class Admin_Settings {
 				esc_html__( 'Settings Saved', 'aspireupdate' ),
 				'success'
 			);
-			settings_errors( $this->option_name );
 		}
 	}
 

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -380,6 +380,7 @@ class Admin_Settings {
 		Utilities::include_file(
 			'page-admin-settings.php',
 			[
+				'options_base' => $this->options_base,
 				'reset_url'    => $reset_url,
 				'option_group' => $this->option_group,
 			]

--- a/includes/views/page-admin-settings.php
+++ b/includes/views/page-admin-settings.php
@@ -1,12 +1,13 @@
 <?php
 namespace AspireUpdate;
 
+$options_base = $args['options_base'] ?? '';
 $reset_url    = $args['reset_url'] ?? '';
 $option_group = $args['option_group'] ?? '';
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'AspireUpdate Settings', 'aspireupdate' ); ?></h1>
-	<form id="aspireupdate-settings-form" method="post" action="index.php?page=aspireupdate-settings">
+	<form id="aspireupdate-settings-form" method="post" action="<?php echo esc_url( network_admin_url( $options_base ) ); ?>?page=aspireupdate-settings">
 		<?php
 		settings_fields( $option_group );
 		do_settings_sections( 'aspireupdate-settings' );

--- a/tests/e2e/data/routes.ts
+++ b/tests/e2e/data/routes.ts
@@ -1,5 +1,5 @@
 
-export const settings = 'index.php?page=aspireupdate-settings';
+export const settings = 'options-general.php?page=aspireupdate-settings';
 export const plugins = 'plugins.php';
 export const pluginInstall = 'plugin-install.php';
 export const themes = 'themes.php';

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_AdminEnqueueScriptsTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_AdminEnqueueScriptsTest.php
@@ -27,14 +27,8 @@ class AdminSettings_AdminEnqueueScriptsTest extends AdminSettings_UnitTestCase {
 	 * Test that the stylesheet is enqueued on the settings screen.
 	 */
 	public function test_should_enqueue_style() {
+		$hook           = 'settings_page_aspireupdate-settings';
 		$admin_settings = new AspireUpdate\Admin_Settings();
-
-		if ( is_multisite() ) {
-			$hook = 'index_page_aspireupdate-settings';
-		} else {
-			$hook = 'dashboard_page_aspireupdate-settings';
-		}
-
 		$admin_settings->admin_enqueue_scripts( $hook );
 
 		$this->assertTrue( wp_style_is( 'aspire_update_settings_css' ) );
@@ -61,14 +55,8 @@ class AdminSettings_AdminEnqueueScriptsTest extends AdminSettings_UnitTestCase {
 	 * Test that the script is enqueued and localized on the settings screen.
 	 */
 	public function test_should_enqueue_and_localize_script() {
+		$hook           = 'settings_page_aspireupdate-settings';
 		$admin_settings = new AspireUpdate\Admin_Settings();
-
-		if ( is_multisite() ) {
-			$hook = 'index_page_aspireupdate-settings';
-		} else {
-			$hook = 'dashboard_page_aspireupdate-settings';
-		}
-
 		$admin_settings->admin_enqueue_scripts( $hook );
 
 		$this->assertTrue(

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_AdminNoticesTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_AdminNoticesTest.php
@@ -120,29 +120,6 @@ class AdminSettings_AdminNoticesTest extends AdminSettings_UnitTestCase {
 	}
 
 	/**
-	 * Test that the reset notice is output.
-	 */
-	public function test_should_output_reset_notice() {
-		update_site_option( 'aspireupdate-reset', 'true' );
-		$_GET['reset-success']       = 'success';
-		$_GET['reset-success-nonce'] = wp_create_nonce( 'aspireupdate-reset-success-nonce' );
-
-		if ( is_multisite() ) {
-			grant_super_admin( wp_get_current_user()->ID );
-		}
-
-		$admin_settings = new \AspireUpdate\Admin_Settings();
-		$actual         = get_echo( [ $admin_settings, 'admin_notices' ] );
-
-		unset( $_GET['reset-success'], $_GET['reset-success-nonce'] );
-
-		$this->assertStringContainsString(
-			'aspireupdate_settings_reset',
-			$actual
-		);
-	}
-
-	/**
 	 * Test that the 'aspireupdate-reset' option is deleted.
 	 */
 	public function test_should_delete_aspireupdatereset_option_after_output() {
@@ -186,26 +163,5 @@ class AdminSettings_AdminNoticesTest extends AdminSettings_UnitTestCase {
 		unset( $_GET['settings-updated-wpnonce'] );
 
 		$this->assertStringNotContainsString( 'aspireupdate_settings_saved', $actual );
-	}
-
-	/**
-	 * Test that the saved notice is output.
-	 */
-	public function test_should_output_saved_notice() {
-		$_GET['settings-updated-wpnonce'] = wp_create_nonce( 'aspireupdate-settings-updated-nonce' );
-
-		if ( is_multisite() ) {
-			grant_super_admin( wp_get_current_user()->ID );
-		}
-
-		$admin_settings = new \AspireUpdate\Admin_Settings();
-		$actual         = get_echo( [ $admin_settings, 'admin_notices' ] );
-
-		unset( $_GET['settings-updated-wpnonce'] );
-
-		$this->assertStringContainsString(
-			'aspireupdate_settings_saved',
-			$actual
-		);
 	}
 }

--- a/tests/phpunit/tests/AdminSettings/AdminSettings_RegisterAdminMenuTest.php
+++ b/tests/phpunit/tests/AdminSettings/AdminSettings_RegisterAdminMenuTest.php
@@ -66,18 +66,19 @@ class AdminSettings_RegisterAdminMenuTest extends AdminSettings_UnitTestCase {
 			'There are no submenus.'
 		);
 
+		$base = is_multisite() ? 'settings.php' : 'options-general.php';
 		$this->assertArrayHasKey(
-			'index.php',
+			$base,
 			$submenu,
 			'There is no dashboard section.'
 		);
 
 		$this->assertIsArray(
-			$submenu['index.php'],
+			$submenu[ $base ],
 			'There are no submenus for the dashboard.'
 		);
 
-		$last_menu_item = end( $submenu['index.php'] );
+		$last_menu_item = end( $submenu[ $base ] );
 		$this->assertSame(
 			'aspireupdate-settings',
 			$last_menu_item[2],


### PR DESCRIPTION
# Pull Request

## What changed?

This moves the admin settings to the Settings menu.

## Why did it change?

The previous location in the Dashboard menu was uncommon and could lead to confusion for users.

## Did you fix any specific issues?

Fixes #210

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

