### PR TITLE
Randomize Log File Name

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -58,6 +58,7 @@ class Admin_Settings {
 		add_action( 'admin_init', [ $this, 'register_settings' ] );
 		add_action( is_multisite() ? 'network_admin_notices' : 'admin_notices', [ $this, 'admin_notices' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+		add_action( 'update_option_' . $this->option_name, [ $this, 'update_option' ], 10, 2 );
 
 		add_action( 'admin_init', [ $this, 'update_settings' ] );
 		add_action( 'network_admin_edit_aspireupdate-settings', [ $this, 'update_settings' ] );
@@ -679,5 +680,24 @@ class Admin_Settings {
 		$sanitized_input['disable_ssl_verification'] = (int) ! empty( $input['disable_ssl_verification'] );
 
 		return $sanitized_input;
+	}
+
+	/**
+	 * Spring cleaning when the options are updated.
+	 *
+	 * @param array $old_value The old option value
+	 * @param array $new_value The new option value
+	 *
+	 * @return void
+	 */
+	public function update_option( $old_value, $new_value ) {
+		if (
+			isset( $old_value['enable_debug'] ) &&
+			( $old_value['enable_debug'] ) &&
+			isset( $new_value['enable_debug'] ) &&
+			( ! $new_value['enable_debug'] )
+		) {
+			Debug::clear();
+		}
 	}
 }

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -692,10 +692,8 @@ class Admin_Settings {
 	 */
 	public function update_option( $old_value, $new_value ) {
 		if (
-			isset( $old_value['enable_debug'] ) &&
-			( $old_value['enable_debug'] ) &&
-			isset( $new_value['enable_debug'] ) &&
-			( ! $new_value['enable_debug'] )
+			isset( $old_value['enable_debug'] ) && $old_value['enable_debug'] &&
+			isset( $new_value['enable_debug'] ) && ! $new_value['enable_debug']
 		) {
 			Debug::clear();
 		}

--- a/includes/class-debug.php
+++ b/includes/class-debug.php
@@ -13,13 +13,6 @@ namespace AspireUpdate;
 class Debug {
 
 	/**
-	 * Name of the debug log file.
-	 *
-	 * @var string
-	 */
-	private static $log_file = 'debug-aspire-update.log';
-
-	/**
 	 * The filesystem.
 	 *
 	 * @var Filesystem_Direct
@@ -27,12 +20,27 @@ class Debug {
 	private static $filesystem;
 
 	/**
+	 * Generates a random file name for the log file.
+	 *
+	 * @return string The Log file name.
+	 */
+	private static function generate_log_file_name() {
+		return '.debug-aspire-update-' . wp_generate_password( 12, false, false ) . '.log';
+	}
+
+	/**
 	 * Get the Log file path.
 	 *
 	 * @return string The Log file path.
 	 */
 	private static function get_file_path() {
-		return WP_CONTENT_DIR . '/' . self::$log_file;
+		$log_file = get_option( 'ap_log_file_name', false );
+		if ( false === $log_file ) {
+			$log_file = self::generate_log_file_name();
+			update_option( 'ap_log_file_name', $log_file );
+		}
+
+		return WP_CONTENT_DIR . '/' . $log_file;
 	}
 
 	/**
@@ -88,11 +96,9 @@ class Debug {
 			return new \WP_Error( 'not_accessible', __( 'Error: Unable to access the log file.', 'aspireupdate' ) );
 		}
 
-		$wp_filesystem->put_contents(
-			$file_path,
-			'',
-			FS_CHMOD_FILE
-		);
+		$wp_filesystem->delete( $file_path );
+		delete_option( 'ap_log_file_name' );
+
 		return true;
 	}
 

--- a/tests/phpunit/tests/Debug/Debug_ClearTest.php
+++ b/tests/phpunit/tests/Debug/Debug_ClearTest.php
@@ -56,9 +56,9 @@ class Debug_ClearTest extends Debug_UnitTestCase {
 	}
 
 	/**
-	 * Test that the log file is cleared.
+	 * Test that the log file is deleted.
 	 */
-	public function test_should_clear_log_file() {
+	public function test_should_delete_log_file() {
 		file_put_contents(
 			self::$log_file,
 			"First line\r\nSecond line\r\nThird line"
@@ -71,15 +71,9 @@ class Debug_ClearTest extends Debug_UnitTestCase {
 
 		AspireUpdate\Debug::clear();
 
-		$this->assertFileExists(
+		$this->assertFileDoesNotExist(
 			self::$log_file,
-			'The log file was deleted.'
-		);
-
-		$this->assertSame(
-			'',
-			file_get_contents( self::$log_file ),
-			'The log file was not cleared.'
+			'The log file was not deleted.'
 		);
 	}
 }


### PR DESCRIPTION
# Pull Request

## What changed?

1) Randomize Log File Name
2) Delete the Log file instead of just clearing the contents when the clear log option is used. 
3) Delete the log file when the Debug mode changes from On to Off

## Why did it change?

The Debug file name being easily guessable and potentially publicly accessible on unsecured servers will cause a security risk.
Now the Debug file name is randomized and changed each time its cleared or the debug mode toggled.

## Did you fix any specific issues?

Fixes #201 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

