### PR TITLE
update releases workflow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     name: Upload Release Asset
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      id-token: write
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,3 +31,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip
+
+      - name: Build provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip


### PR DESCRIPTION
# Pull Request

Update to releases workflow. Added permissions and attestation.

## Why did it change?

Seems the workflow requires additional permissions not in current repo settings.

## Did you fix any specific issues?

Hopefully it now runs and completes.

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

