### PR TITLE
The generate-pot workflow requires the branch name

### DIFF
--- a/.github/workflows/generate-pot-pr.yml
+++ b/.github/workflows/generate-pot-pr.yml
@@ -3,8 +3,9 @@ name: Generate POT PR
 on:
   workflow_dispatch:
   push:
-    tags:
-      - "**"
+    branches:
+      - main
+
 jobs:
   generate-pot:
     name: Generate POT PR


### PR DESCRIPTION
Therefore doesn't work when triggered on the tag.

https://github.com/aspirepress/aspireupdate/actions/runs/13507397017/job/37741272037
