### PR TITLE
Prevent Updating AU via API

### DIFF
--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -22,6 +22,7 @@ class Controller {
 		$this->api_rewrite();
 		add_action( 'wp_ajax_aspireupdate_clear_log', [ $this, 'clear_log' ] );
 		add_action( 'wp_ajax_aspireupdate_read_log', [ $this, 'read_log' ] );
+		add_filter( 'site_transient_update_plugins', [ $this, 'check_self_update_notifications' ] );
 	}
 
 	/**
@@ -124,5 +125,20 @@ class Controller {
 				'content' => $content,
 			]
 		);
+	}
+
+	/**
+	 * Hide Aspire Update plugin from plugin update notifications.
+	 * This is to prevent supply chain attacks via unverified API providers.
+	 *
+	 * @param object $value The Update Notifications Data.
+	 *
+	 * @return object $value The Update Notifications Data.
+	 */
+	public function check_self_update_notifications( $value ) {
+		if ( isset( $value->response['aspireupdate/aspire-update.php'] ) ) {
+			unset( $value->response['aspireupdate/aspire-update.php'] );
+		}
+		return $value;
 	}
 }


### PR DESCRIPTION
# Pull Request

## What changed?

Prevent Updating AU via API.
This PR prevents showing Aspire Update in the plugin search results as well as remove any update notifications for Aspire Update plugin to prevent the plugin from getting updated via the APIs.

## Why did it change?

This is a special case consideration for AspireUpdate plugin considering its importance in the supply chain and to prevent Supply Chain Attacks.

## Did you fix any specific issues?

Fixes #325 
Fixes #324 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

