### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,8 +3,10 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .editorconfig export-ignore
+.nvmrc export-ignore
 .package.json export-ignore
 .package-lock.json export-ignore
+.wp-env.json export-ignore
 composer.lock export-ignore
 phpunit.xml export-ignore
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
include .nvmrc and .wp-env.json

# Pull Request

## What changed?

Added .nvmrc and .wp-env.json to .gitattributes export-ignore

## Why did it change?

these files are not needed for the user


## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

