### PR TITLE
Build: Correct `package.json` paths.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,11 +4,11 @@
 .gitignore export-ignore
 .editorconfig export-ignore
 .nvmrc export-ignore
-.package.json export-ignore
-.package-lock.json export-ignore
 .pre-commit-config.yaml export-ignore
 .wp-env.json export-ignore
 composer.lock export-ignore
+package.json export-ignore
+package-lock.json export-ignore
 phpunit.xml export-ignore
 phpunit.xml.dist export-ignore
 phpcs.xml export-ignore


### PR DESCRIPTION
# Pull Request

## What changed?

- Corrected `.package.json` to `package.json`.
- Corrected `.package-lock.json` to `package-lock.json`.

## Why did it change?

These files are not prefixed with `.`

## Did you fix any specific issues?

Fixes #345

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

