### PR TITLE
I18N: Make the "Request Failed" comment consistent.

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -272,7 +272,7 @@ class API_Rewrite {
 						$message = wp_remote_retrieve_response_message( $response );
 						Debug::log_string(
 							sprintf(
-								/* translators: %s: The response message. */
+								/* translators: %s: The error message. */
 								__( 'Request Failed: %s', 'aspireupdate' ),
 								$message
 							)


### PR DESCRIPTION
# Pull Request

## What changed?

Changed
```php
/* translators: %s: The response message. */
```
to
```php
/* translators: %s: The error message. */
```

## Why did it change?

Translator comments for the same string must be consistent.

## Did you fix any specific issues?

Fixes #346 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

