### PR TITLE
Update releases.yml

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build project
-        run: git archive -o /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip --prefix=${{ github.event.repository.name }}/ ${{ steps.tag.outputs.tag }}
+        run: git archive -o /tmp/${{ github.event.repository.name }}.zip --prefix=${{ github.event.repository.name }}/ ${{ steps.tag.outputs.tag }}
 
       - name: Create Release
         id: create_release
@@ -38,9 +38,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip
+          files: /tmp/${{ github.event.repository.name }}.zip
 
       - name: Build provenance attestation
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
-          subject-path: /tmp/${{ github.event.repository.name }}-${{ steps.tag.outputs.tag }}.zip
+          subject-path: /tmp/${{ github.event.repository.name }}.zip


### PR DESCRIPTION
# Pull Request

## What changed?

Testing renaming the build zip file after removing the tag from the zip name.

## Why did it change?

The tag no in the zip file name is breaking GITHUB functionality of automatically pointing to the latest release via the url https://github.com/aspirepress/aspireupdate/releases/latest/download/aspireupdate.zip

## Did you fix any specific issues?

None

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

