### PR TITLE
Conditionally skip API rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,25 @@ The plugin menu appears under the Settings main menu item.
 
 The plugin can use the following configuration options in wp-config.php:
 
-| Configuration Parameter |                                                                                              Description |                        Default, if any |
-| :---------------------- | -------------------------------------------------------------------------------------------------------: | -------------------------------------: |
-| AP_ENABLE               |                                                                                       Enable API rewrite |                                  false |
-| AP_API_KEY              |                                                     The API Key for AspireCloud (not currently enforced) |                                        |
-| AP_HOST                 |                                                                                          API domain name |                    api.aspirecloud.net |
-| AP_DEBUG                |                                                                                        Enable Debug Mode |                                  false |
-| AP_DEBUG_TYPES          |                                                                                  an array of debug modes | array('string', 'request', 'response') |
-| AP_DISABLE_SSL          |                                                              Disabled SSL verification for local testing |                                   true |
-| AP_REMOVE_UI            | Disables plugin settings user interface and branding, defaults to config parameters set in wp-config.php |                                  false |
+| Configuration Parameter        |                                                                                              Description |                                            Default, if any |
+| :----------------------------- | -------------------------------------------------------------------------------------------------------: | ---------------------------------------------------------: |
+| AP_ENABLE                      |                                                                                       Enable API rewrite |                                                      false |
+| AP_API_KEY                     |                                                     The API Key for AspireCloud (not currently enforced) |                                                            |
+| AP_HOST                        |                                                                                          API domain name |                                        api.aspirecloud.net |
+| AP_COMPATIBILITY               |                                                                Configure various compatibility measures. |     array( 'skip_rewriting_on_existing_response' => true ) |
+| AP_DEBUG                       |                                                                                        Enable Debug Mode |                                                      false |
+| AP_DEBUG_TYPES                 |                                                                                  an array of debug modes |                     array('string', 'request', 'response') |
+| AP_DISABLE_SSL                 |                                                              Disabled SSL verification for local testing |                                                       true |
+| AP_REMOVE_UI                   | Disables plugin settings user interface and branding, defaults to config parameters set in wp-config.php |                                                      false |
+
+To set AP_COMPATIBILITY use an array to define the constant:
+
+```php
+// Works as of PHP 7
+define('AP_COMPATIBILITY', array(
+    'skip_rewriting_on_existing_response' => true
+));
+```
 
 To set AP_DEBUG_TYPES use an array to define the constant:
 

--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -138,7 +138,8 @@ class ApiRewrites {
 		init() {
 			ApiRewrites.enabled_rewrites.sub_fields = [
 				ApiRewrites.host_selector,
-				ApiRewrites.api_key
+				ApiRewrites.api_key,
+				ApiRewrites.compatibility
 			];
 
 			ApiRewrites.enabled_rewrites.field.change(function () {
@@ -303,6 +304,9 @@ class ApiRewrites {
 		hide_error() {
 			ApiRewrites.api_key.field.parent().find('.error').html('').hide();
 		}
+	}
+	static compatibility = {
+		field: jQuery('.aspireupdate-settings-field-wrapper-compatibility'),
 	}
 }
 

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -193,6 +193,24 @@ class API_Rewrite {
 			if ( false !== strpos( $url, $this->default_host ) ) {
 				Debug::log_string( __( 'Default API Found: ', 'aspireupdate' ) . $url );
 
+				if ( false !== $response ) {
+					$admin_settings = \AspireUpdate\Admin_Settings::get_instance();
+					$compatibility  = $admin_settings->get_setting( 'compatibility' );
+
+					if ( ! empty( $compatibility['skip_rewriting_on_existing_response'] ) ) {
+						Debug::log_string(
+							sprintf(
+								/* translators: 1: The options' name, 2: The constant's name, 3: The explicitly required value. */
+								__( 'API rewriting has been skipped because the response has already been changed. Enable the %1$s option or set "%1$s" in the %2$s constant to %3$s to continue with API rewriting in future.', 'aspireupdate' ),
+								'skip_rewriting_on_existing_response',
+								'AP_COMPATIBILITY',
+								'true'
+							)
+						);
+						return $response;
+					}
+				}
+
 				if ( false === filter_var( $this->redirected_host, FILTER_VALIDATE_URL ) ) {
 					$error_message = __( 'Your API host is not a valid URL.', 'aspireupdate' );
 					Debug::log_string(

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -56,7 +56,7 @@ class API_Rewrite {
 		$this->api_key     = $api_key;
 
 		if ( Admin_Settings::get_instance()->get_setting( 'enable', false ) ) {
-			add_filter( 'pre_http_request', [ $this, 'pre_http_request' ], 10, 3 );
+			add_filter( 'pre_http_request', [ $this, 'pre_http_request' ], PHP_INT_MAX, 3 );
 		}
 	}
 

--- a/tests/e2e/admin-settings/compatibility.spec.ts
+++ b/tests/e2e/admin-settings/compatibility.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { fieldWrapperSelector, fieldSelector, enable, compatibility } from '../data/fields';
+import { settings } from '../data/routes';
+
+test.describe('[Admin Settings] [Field] Compatibility', () => {
+	test.beforeEach(async ({ page }) => {
+		const baseURL = test.info().project.use.baseURL;
+		const settingsPage = `${baseURL}/wp-admin/${settings}`;
+		await page.goto(settingsPage);
+		await page.waitForURL(settingsPage);
+	});
+
+	test('is invisible by default', async ({ page }) => {
+		await expect(page.locator(fieldWrapperSelector + compatibility)).not.toBeVisible();
+	});
+
+	test('is visible when API rewriting is enabled', async ({ page }) => {
+		await page.locator(fieldSelector + enable).check();
+		await expect(page.locator(fieldWrapperSelector + compatibility)).toBeVisible();
+	});
+})

--- a/tests/e2e/admin-settings/skip_rewriting_on_existing_response.spec.ts
+++ b/tests/e2e/admin-settings/skip_rewriting_on_existing_response.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { fieldSelector, enable, skip_rewriting_on_existing_response } from '../data/fields';
+import { settings } from '../data/routes';
+
+test.describe('[Admin Settings] [Field] Compatibility: Skip API Rewriting', () => {
+	test.beforeEach(async ({ page }) => {
+		const baseURL = test.info().project.use.baseURL;
+		const settingsPage = `${baseURL}/wp-admin/${settings}`;
+		await page.goto(settingsPage);
+		await page.waitForURL(settingsPage);
+	});
+
+	test('is not visible by default', async ({ page }) => {
+		await expect(page.locator(fieldSelector + skip_rewriting_on_existing_response)).not.toBeVisible();
+	});
+
+	test('is visible when API rewriting is enabled', async ({ page }) => {
+		await page.locator(fieldSelector + enable).check();
+		await expect(page.locator(fieldSelector + skip_rewriting_on_existing_response)).toBeVisible();
+	});
+})

--- a/tests/e2e/data/fields.ts
+++ b/tests/e2e/data/fields.ts
@@ -1,9 +1,12 @@
 
+export const fieldWrapperSelector = '.aspireupdate-settings-field-wrapper-';
 export const fieldSelector = '#aspireupdate-settings-field-';
 export const enable = 'enable';
 export const api_host = 'api_host';
 export const api_host_other = 'api_host_other';
 export const api_key = 'api_key';
+export const compatibility = 'compatibility';
+export const skip_rewriting_on_existing_response = 'compatibility-skip_rewriting_on_existing_response';
 export const enable_debug = 'enable_debug';
 export const debug_request = 'enable_debug_type-request';
 export const debug_response = 'enable_debug_type-response';

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -55,7 +55,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $request, 'filter' ] );
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( '', false, '' );
-		$api_rewrite->pre_http_request( [], [], '' );
+		$api_rewrite->pre_http_request( false, [], '' );
 
 		$this->assertSame( 0, $request->get_call_count() );
 	}
@@ -70,7 +70,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		$default_host = $this->get_default_host();
 		$api_rewrite  = new AspireUpdate\API_Rewrite( $default_host, false, '' );
 
-		$api_rewrite->pre_http_request( [], [], $default_host );
+		$api_rewrite->pre_http_request( false, [], $default_host );
 
 		$this->assertSame( 0, $request->get_call_count() );
 	}
@@ -93,7 +93,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', false, '' );
 		$api_rewrite->pre_http_request(
-			[],
+			false,
 			[ 'sslverify' => 'original_sslverify_value' ],
 			'https://' . $this->get_default_host()
 		);
@@ -119,7 +119,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, '' );
 		$api_rewrite->pre_http_request(
-			[],
+			false,
 			[ 'sslverify' => true ],
 			'https://' . $this->get_default_host()
 		);
@@ -146,7 +146,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		);
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, '' );
-		$api_rewrite->pre_http_request( [], [], 'https://' . $this->get_default_host() );
+		$api_rewrite->pre_http_request( false, [], 'https://' . $this->get_default_host() );
 
 		$this->assertMatchesRegularExpression( '/my\.api\.org\?cache_buster=[0-9]+/', $actual );
 	}
@@ -171,7 +171,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_key     = 'MY_API_KEY';
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, $api_key );
-		$api_rewrite->pre_http_request( [], [], 'https://' . $this->get_default_host() );
+		$api_rewrite->pre_http_request( false, [], 'https://' . $this->get_default_host() );
 
 		$this->assertIsArray(
 			$actual,
@@ -231,7 +231,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, 'MY_API_KEY' );
 		$api_rewrite->pre_http_request(
-			[],
+			false,
 			[],
 			untrailingslashit( 'https://' . $this->get_default_host() ) . $path
 		);
@@ -317,7 +317,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, 'MY_API_KEY' );
 		$api_rewrite->pre_http_request(
-			[],
+			false,
 			[],
 			'https://' . $this->get_default_host() . $path
 		);
@@ -404,7 +404,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		// No API key ensures no Authorization header will be already set.
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, '' );
 		$api_rewrite->pre_http_request(
-			[],
+			false,
 			[],
 			'https://' . $this->get_default_host() . '/file.php'
 		);
@@ -456,7 +456,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', false, '' );
 		$api_rewrite->pre_http_request(
-			[],
+			false,
 			[
 				'body' => [
 					'plugins' => wp_json_encode( [ 'plugins' => $plugins ] ),
@@ -541,7 +541,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', false, '' );
 		$actual      = $api_rewrite->pre_http_request(
-			[],
+			false,
 			[ 'body' => $body ],
 			'https://' . $this->get_default_host() . '/plugins/info/1.0/'
 		);
@@ -590,7 +590,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		wp_cache_set( 'plugins', [ '' => $plugins ], 'plugins' );
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', false, '' );
 		$actual      = $api_rewrite->pre_http_request(
-			[],
+			false,
 			[
 				'body' => [
 					'plugins' => wp_json_encode( [ 'plugins' => $plugins ] ),
@@ -768,7 +768,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', false, '' );
 		$response    = $api_rewrite->pre_http_request(
-			[],
+			false,
 			[],
 			'https://' . $this->get_default_host() . '/plugins/info/1.0/'
 		);
@@ -831,7 +831,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, '' );
 		$actual      = $api_rewrite->pre_http_request(
-			[],
+			false,
 			[],
 			$this->get_default_host() . '/file.php'
 		);
@@ -883,7 +883,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, '' );
 		$actual      = $api_rewrite->pre_http_request(
-			[],
+			false,
 			[],
 			'https://' . $this->get_default_host() . '/file.php'
 		);
@@ -925,7 +925,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 	public function test_should_return_wp_error_for_redirected_host_that_is_an_invalid_url() {
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'my.api.org', true, '' );
 		$actual      = $api_rewrite->pre_http_request(
-			[],
+			false,
 			[],
 			'https://' . $this->get_default_host() . '/file.php'
 		);

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -944,6 +944,164 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that API rewriting is skipped when the 'AP_COMPATIBILITY'
+	 * constant has 'skip_rewriting_on_existing_response' set to false.
+	 *
+	 * This test causes constants to be defined.
+	 * It must run in separate processes and must not preserve global state.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_not_skip_api_rewriting_when_the_ap_compatibility_constant_has_skip_rewriting_on_existing_response_set_to_false() {
+		define( 'AP_ENABLE', true );
+		define( 'AP_COMPATIBILITY', [ 'skip_rewriting_on_existing_response' => false ] );
+
+		$default_host = 'https://' . $this->get_default_host();
+
+		add_filter(
+			'pre_http_request',
+			static function ( $response, $parsed_args, $url ) use ( $default_host ) {
+				if ( $default_host === $url ) {
+					return [ 'body' => 'Test Response' ];
+				}
+
+				return $response;
+			},
+			0,
+			3
+		);
+
+		new \AspireUpdate\API_Rewrite( 'my.api.org', true, '' );
+		$response = wp_remote_get( $default_host );
+		$body     = wp_remote_retrieve_body( $response );
+
+		$this->assertNotSame( 'Test Response', $body );
+	}
+
+	/**
+	 * Test that API rewriting is skipped when the 'skip_rewriting_on_existing_response'
+	 * option is disabled.
+	 *
+	 * This test causes constants to be defined.
+	 * It must run in separate processes and must not preserve global state.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_not_skip_api_rewriting_when_the_skip_rewriting_on_existing_response_option_is_disabled() {
+		update_site_option(
+			'aspireupdate_settings',
+			[
+				'enable'        => 1,
+				'compatibility' => [
+					'skip_rewriting_on_existing_response' => 0,
+				],
+			]
+		);
+
+		$default_host = 'https://' . $this->get_default_host();
+
+		add_filter(
+			'pre_http_request',
+			static function ( $response, $parsed_args, $url ) use ( $default_host ) {
+				if ( $default_host === $url ) {
+					return [ 'body' => 'Test Response' ];
+				}
+
+				return $response;
+			},
+			0,
+			3
+		);
+
+		new \AspireUpdate\API_Rewrite( 'my.api.org', true, '' );
+		$response = wp_remote_get( $default_host );
+		$body     = wp_remote_retrieve_body( $response );
+
+		$this->assertNotSame( 'Test Response', $body );
+	}
+
+	/**
+	 * Test that API rewriting is skipped when the 'AP_COMPATIBILITY'
+	 * constant has 'skip_rewriting_on_existing_response' set to true.
+	 *
+	 * This test causes constants to be defined.
+	 * It must run in separate processes and must not preserve global state.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_skip_api_rewriting_when_the_ap_compatibility_constant_has_skip_rewriting_on_existing_response_set_to_true() {
+		define( 'AP_ENABLE', true );
+		define( 'AP_COMPATIBILITY', [ 'skip_rewriting_on_existing_response' => true ] );
+
+		$default_host = 'https://' . $this->get_default_host();
+
+		add_filter(
+			'pre_http_request',
+			static function ( $response, $parsed_args, $url ) use ( $default_host ) {
+				if ( $default_host === $url ) {
+					return [ 'body' => 'Test Response' ];
+				}
+
+				return $response;
+			},
+			0,
+			3
+		);
+
+		new \AspireUpdate\API_Rewrite( 'my.api.org', true, '' );
+		$response = wp_remote_get( $default_host );
+		$body     = wp_remote_retrieve_body( $response );
+
+		$this->assertSame( 'Test Response', $body );
+	}
+
+	/**
+	 * Test that API rewriting is skipped when the 'skip_rewriting_on_existing_response'
+	 * option is enabled.
+	 *
+	 * This test causes constants to be defined.
+	 * It must run in separate processes and must not preserve global state.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_skip_api_rewriting_when_the_skip_rewriting_on_existing_response_option_is_enabled() {
+		update_site_option(
+			'aspireupdate_settings',
+			[
+				'enable'        => 1,
+				'compatibility' => [
+					'skip_rewriting_on_existing_response' => 1,
+				],
+			]
+		);
+
+		$default_host = 'https://' . $this->get_default_host();
+
+		add_filter(
+			'pre_http_request',
+			static function ( $response, $parsed_args, $url ) use ( $default_host ) {
+				if ( $default_host === $url ) {
+					return [ 'body' => 'Test Response' ];
+				}
+
+				return $response;
+			},
+			0,
+			3
+		);
+
+		new \AspireUpdate\API_Rewrite( 'my.api.org', true, '' );
+		$response = wp_remote_get( $default_host );
+		$body     = wp_remote_retrieve_body( $response );
+
+		$this->assertSame( 'Test Response', $body );
+	}
+
+	/**
 	 * Gets the default host.
 	 *
 	 * @return string The default host.


### PR DESCRIPTION
# Pull Request

## What changed?

- Added a new checkbox option, `skip_rewriting_on_existing_response`.
- Added a new constant, `AP_COMPATIBILITY`.
- Added a guard to return an existing `$response` in `API_Rewrite::pre_http_request()` if `$response` is not `false` and the `skip_rewriting_on_existing_response` option is enabled.
- Added E2E and PHPUnit tests. This includes fixing existing tests to replace an erroneous default `[]` `$response` value with `false`.
- Added the `AP_COMPATIBILITY` constant to `README.md`.

## Why did it change?

If another plugin has filtered the default host and supplied a non-`false` response, we should not replace that response unless the user has told us to. The new option gives the user control over whether an existing response is respected, or overridden.

## Did you fix any specific issues?

Fixes #358 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

