### PR TITLE
API_Rewrite: Specify hook priority in all  `*_filter()` calls.

### DIFF
--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -275,9 +275,9 @@ class API_Rewrite {
 					/**
 					 * Temporarily Unhook Filter to prevent recursion.
 					 */
-					remove_filter( 'pre_http_request', [ $this, 'pre_http_request' ] );
+					remove_filter( 'pre_http_request', [ $this, 'pre_http_request' ], PHP_INT_MAX );
 					$response = wp_remote_request( $updated_url, $parsed_args );
-					add_filter( 'pre_http_request', [ $this, 'pre_http_request' ], 10, 3 );
+					add_filter( 'pre_http_request', [ $this, 'pre_http_request' ], PHP_INT_MAX, 3 );
 
 					Debug::log_response( $response );
 


### PR DESCRIPTION
This ensures the filter is added and removed when expected.

# Pull Request

## What changed?

- Added `PHP_INT_MAX` as the `$priority` before and after the rewritten request in `API_Rewrite::pre_http_request()`.

## Why did it change?

To ensure the hooked callback is added and removed when expected.

## Did you fix any specific issues?

Fixes #365 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

