### PR TITLE
Workflows: Run PHPUnit tests against PHP 8.4.

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.4', '8.3']
+        php-version: ['7.4', '8.4']
         multisite: [ true, false ]
     services:
       database:


### PR DESCRIPTION
# Pull Request

## What changed?

The PHPUnit tests workflow previously ran against PHP 7.4 and 8.3. It now runs against PHP 7.4 and PHP 8.4.

## Why did it change?

The latest version of PHP is 8.4.

## Did you fix any specific issues?

Fixes #373 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

