### PR TITLE
Branding: Change "Learn more" to "Learn about AspireUpdate".

### DIFF
--- a/includes/class-branding.php
+++ b/includes/class-branding.php
@@ -94,7 +94,7 @@ class Branding {
 			case 'plugin-install-network':
 				$message = sprintf(
 					/* translators: 1: The name of the plugin, 2: The documentation URL. */
-					__( 'Your plugin updates are now powered by <strong>%1$s</strong>. <a href="%2$s">Learn more</a>', 'aspireupdate' ),
+					__( 'Your plugin updates are now powered by <strong>%1$s</strong>. <a href="%2$s">Learn about %1$s</a>', 'aspireupdate' ),
 					'AspireUpdate',
 					__( 'https://docs.aspirepress.org/aspireupdate/', 'aspireupdate' )
 				);
@@ -109,7 +109,7 @@ class Branding {
 			case 'theme-install-network':
 				$message = sprintf(
 					/* translators: 1: The name of the plugin, 2: The documentation URL. */
-					__( 'Your theme updates are now powered by <strong>%1$s</strong>. <a href="%2$s">Learn more</a>', 'aspireupdate' ),
+					__( 'Your theme updates are now powered by <strong>%1$s</strong>. <a href="%2$s">Learn about %1$s</a>', 'aspireupdate' ),
 					'AspireUpdate',
 					__( 'https://docs.aspirepress.org/aspireupdate/', 'aspireupdate' )
 				);
@@ -122,7 +122,7 @@ class Branding {
 			case 'update-core-network':
 				$message = sprintf(
 					/* translators: 1: The name of the plugin, 2: The documentation URL. */
-					__( 'Your WordPress, plugin, theme and translation updates are now powered by <strong>%1$s</strong>. <a href="%2$s">Learn more</a>', 'aspireupdate' ),
+					__( 'Your WordPress, plugin, theme and translation updates are now powered by <strong>%1$s</strong>. <a href="%2$s">Learn about %1$s</a>', 'aspireupdate' ),
 					'AspireUpdate',
 					__( 'https://docs.aspirepress.org/aspireupdate/', 'aspireupdate' )
 				);


### PR DESCRIPTION
# Pull Request

## What changed?

- The "Learn more" text in the branding notice now reads "Learn about AspireUpdate".

Before:
![image](https://github.com/user-attachments/assets/a96b37db-48ac-4ad6-92f5-8064364e270f)

After:
![image](https://github.com/user-attachments/assets/629618a9-b331-4564-b482-4ff28dd08aab)


## Why did it change?

- To avoid conflicts with other link texts.

## Did you fix any specific issues?

See #379 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

