### PR TITLE
Admin_Settings: Use a visual label for the "Generate API Key" button.

### DIFF
--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -295,6 +295,7 @@ class ApiRewrites {
 	static api_key = {
 		field: jQuery('#aspireupdate-settings-field-api_key'),
 		action_button: jQuery('#aspireupdate-generate-api-key'),
+		action_button_label: jQuery('label[for="aspireupdate-generate-api-key"]'),
 		init() {
 			ApiRewrites.api_key.action_button.click(function () {
 				ApiRewrites.api_key.hide_error();
@@ -331,9 +332,11 @@ class ApiRewrites {
 		},
 		show_action_button() {
 			ApiRewrites.api_key.action_button.show();
+			ApiRewrites.api_key.action_button_label.show();
 		},
 		hide_action_button() {
 			ApiRewrites.api_key.action_button.hide();
+			ApiRewrites.api_key.action_button_label.hide();
 		},
 		make_required() {
 			ApiRewrites.api_key.field.prop('required', true);

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -646,7 +646,8 @@ class Admin_Settings {
 			case 'api-key':
 				?>
 					<input type="text" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>" class="regular-text" aria-describedby="<?php echo esc_attr( $description_id ); ?>" />
-					<input type="button" id="aspireupdate-generate-api-key" value="Generate API Key" title="<?php esc_attr_e( 'Generate API Key', 'aspireupdate' ); ?>" />
+					<input type="button" id="aspireupdate-generate-api-key" value="Generate API Key" />
+					<label for="aspireupdate-generate-api-key"><?php esc_html_e( 'Generate API Key', 'aspireupdate' ); ?></label>
 					<p class="error"></p>
 					<?php
 				break;


### PR DESCRIPTION
# Pull Request

## What changed?

- The "Generate API Key" button now has a visual label.
  - The label uses the value previously used in the button's `title` attribute.
  - The button's `title` attribute has now been removed.

Before:
![image](https://github.com/user-attachments/assets/06285931-520b-489d-968e-8cd3451ea7bc)

After:
![image](https://github.com/user-attachments/assets/e0679bd9-ba0c-463f-b59d-5778f0858cc6)


## Why did it change?

The "Generate API Key" button was previously only labelled using a `title` attribute, which does not appear in many contexts, including touch interfaces and some browser configurations.

## Did you fix any specific issues?

See #379 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

