### PR TITLE
Admin_Settings: Improve labels, descriptions and notice placement.

### DIFF
--- a/assets/css/aspire-update.css
+++ b/assets/css/aspire-update.css
@@ -17,21 +17,9 @@
 }
 
 #aspireupdate-generate-api-key {
-	display: inline-block;
-	width: 30px;
-	height: 30px;
-	background: url(../images/icon-key.svg) no-repeat center center / 24px 24px;
-	background-color: #cbcbcb;
-	border: 1px solid #8c8f94;
-	border-radius: 3px;
-	clip-path: inset(0 0 0 0);
-	color: transparent;
-	cursor: pointer;
-	transition: background-color 0.3s ease;
-}
-
-#aspireupdate-generate-api-key:hover {
-	background-color: #e3e3e3;
+	display: inline-flex;
+	align-items: center;
+	gap: .5em;
 }
 
 .aspireupdate-settings-field-wrapper p.error {

--- a/assets/images/icon-key.svg
+++ b/assets/images/icon-key.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z" />
-</svg>

--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -13,7 +13,8 @@ class AdminNotice {
 		args = {
 			type: args.type || 'info',
 			dismissible: typeof args.dismissible !== 'undefined' ? args.dismissible : true,
-			id: args.id || 'aspireupdate-notice'
+			id: args.id || 'aspireupdate-notice',
+			previousSibling: args.previousSibling || jQuery('h1'),
 		};
 
 		let existingNotice = jQuery(`#${args.id}`);
@@ -26,7 +27,7 @@ class AdminNotice {
 		if (existingNotice.length > 0) {
 			existingNotice.replaceWith(adminNotice);
 		} else {
-			jQuery('h1').after(adminNotice);
+			jQuery(args.previousSibling).after(adminNotice);
 		}
 
 		wp.a11y.speak(message);
@@ -70,19 +71,31 @@ class ClearLog {
 					if (response.success) {
 						AdminNotice.add(
 							response.data.message,
-							{type: 'success', id: noticeId}
+							{
+								type: 'success',
+								id: noticeId,
+								previousSibling: ClearLog.clearlog_button.field.parent()
+							}
 						);
 					} else {
 						AdminNotice.add(
 							response.data.message || aspireupdate.unexpected_error,
-							{type: 'error', id: noticeId}
+							{
+								type: 'error',
+								id: noticeId,
+								previousSibling: ClearLog.clearlog_button.field.parent()
+							}
 						);
 					}
 				})
 				.fail(function (response) {
 					AdminNotice.add(
 						response.data.message || aspireupdate.unexpected_error,
-						{type: 'error', id: noticeId}
+						{
+							type: 'error',
+							id: noticeId,
+							previousSibling: ClearLog.clearlog_button.field.parent()
+						}
 					);
 				});
 		},
@@ -152,14 +165,22 @@ class ViewLog {
 					} else {
 						AdminNotice.add(
 							response.data.message || aspireupdate.unexpected_error,
-							{type: 'error', id: noticeId}
+							{
+								type: 'error',
+								id: noticeId,
+								previousSibling: ViewLog.viewlog_button.field.parent()
+							}
 						);
 					}
 				})
 				.fail(function (response) {
 					AdminNotice.add(
 						response.data.message || aspireupdate.unexpected_error,
-						{type: 'error', id: noticeId}
+						{
+							type: 'error',
+							id: noticeId,
+							previousSibling: ViewLog.viewlog_button.field.parent()
+						}
 					);
 				});
 		},
@@ -301,10 +322,8 @@ class ApiRewrites {
 		action_button_label: jQuery('label[for="aspireupdate-generate-api-key"]'),
 		init() {
 			ApiRewrites.api_key.action_button.click(function () {
-				ApiRewrites.api_key.hide_error();
 				ApiRewrites.api_key.get_api_key();
 			});
-			ApiRewrites.api_key.hide_error();
 		},
 		get_api_key() {
 			let parameters = {
@@ -315,15 +334,30 @@ class ApiRewrites {
 					"domain": aspireupdate.domain
 				})
 			};
+			let noticeId = 'aspireupdate-api-key-notice';
 			jQuery.ajax(parameters)
 				.done(function (response) {
 					ApiRewrites.api_key.field.val(response.apikey);
 				})
 				.fail(function (response) {
 					if ((response.status === 400) || (response.status === 401)) {
-						ApiRewrites.api_key.show_error(response.responseJSON?.error);
+						AdminNotice.add(
+							response.responseJSON?.error,
+							{
+								type: 'error',
+								id: noticeId,
+								previousSibling: ApiRewrites.api_key.field.parent().find(':last'),
+							}
+						);
 					} else {
-						ApiRewrites.api_key.show_error(aspireupdate.unexpected_error + ' : ' + response.status);
+						AdminNotice.add(
+							aspireupdate.unexpected_error + ' : ' + response.status,
+							{
+								type: 'error',
+								id: noticeId,
+								previousSibling: ApiRewrites.api_key.field.parent().find(':last'),
+							}
+						);
 					}
 				});
 		},
@@ -346,12 +380,6 @@ class ApiRewrites {
 		},
 		remove_required() {
 			ApiRewrites.api_key.field.prop('required', false);
-		},
-		show_error(message) {
-			ApiRewrites.api_key.field.parent().find('.error').html(message).show();
-		},
-		hide_error() {
-			ApiRewrites.api_key.field.parent().find('.error').html('').hide();
 		}
 	}
 	static compatibility = {

--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -282,7 +282,6 @@ class ApiRewrites {
 			ApiRewrites.other_hosts.field.on("blur", function (event) {
 				let parent = ApiRewrites.other_hosts.field.parent();
 				let current_field = ApiRewrites.other_hosts.field.get(0);
-				console.log(current_field.checkValidity());
 				current_field.setCustomValidity("");
 				if (parent.is(":visible") && !current_field.checkValidity()) {
 					current_field.setCustomValidity(aspireupdate.api_host_other_error);

--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -315,9 +315,9 @@ class ApiRewrites {
 	static api_key = {
 		field: jQuery('#aspireupdate-settings-field-api_key'),
 		action_button: jQuery('#aspireupdate-generate-api-key'),
-		action_button_label: jQuery('label[for="aspireupdate-generate-api-key"]'),
 		init() {
-			ApiRewrites.api_key.action_button.click(function () {
+			ApiRewrites.api_key.action_button.click(function (e) {
+				e.preventDefault();
 				ApiRewrites.api_key.get_api_key();
 			});
 		},
@@ -365,11 +365,9 @@ class ApiRewrites {
 		},
 		show_action_button() {
 			ApiRewrites.api_key.action_button.show();
-			ApiRewrites.api_key.action_button_label.show();
 		},
 		hide_action_button() {
 			ApiRewrites.api_key.action_button.hide();
-			ApiRewrites.api_key.action_button_label.hide();
 		},
 		make_required() {
 			ApiRewrites.api_key.field.prop('required', true);

--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -281,7 +281,6 @@ class ApiRewrites {
 		init() {
 			ApiRewrites.other_hosts.field.on("blur", function (event) {
 				let parent = ApiRewrites.other_hosts.field.parent();
-				let value = ApiRewrites.other_hosts.field.val();
 				let current_field = ApiRewrites.other_hosts.field.get(0);
 				console.log(current_field.checkValidity());
 				current_field.setCustomValidity("");

--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -9,6 +9,7 @@ jQuery(document).ready(function () {
 
 class AdminNotice {
 	static add(message, args) {
+		wp = window.wp || {};
 		args = {
 			type: args.type || 'info',
 			dismissible: typeof args.dismissible !== 'undefined' ? args.dismissible : true,
@@ -27,6 +28,8 @@ class AdminNotice {
 		} else {
 			jQuery('h1').after(adminNotice);
 		}
+
+		wp.a11y.speak(message);
 
 		// Adds dismiss functionality to dismissible notices.
 		jQuery(document).trigger('wp-notice-added');

--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -279,7 +279,7 @@ class ApiRewrites {
 	static other_hosts = {
 		field: jQuery('#aspireupdate-settings-field-api_host_other'),
 		init() {
-			ApiRewrites.other_hosts.field.on("blur", function (event) {
+			ApiRewrites.other_hosts.field.on("blur", function () {
 				let parent = ApiRewrites.other_hosts.field.parent();
 				let current_field = ApiRewrites.other_hosts.field.get(0);
 				current_field.setCustomValidity("");

--- a/assets/js/aspire-update.js
+++ b/assets/js/aspire-update.js
@@ -291,9 +291,7 @@ class ApiRewrites {
 		},
 		show() {
 			ApiRewrites.other_hosts.field.parent().show();
-			ApiRewrites.other_hosts.field.focus();
 			ApiRewrites.other_hosts.make_required();
-			ApiRewrites.other_hosts.field.get(0).reportValidity();
 		},
 		hide() {
 			ApiRewrites.other_hosts.field.get(0).setCustomValidity("");

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -437,15 +437,15 @@ class Admin_Settings {
 
 		add_settings_field(
 			'enable',
-			esc_html__( 'Enable AspireUpdate API Rewrites', 'aspireupdate' ),
+			esc_html__( 'API Rewriting', 'aspireupdate' ),
 			[ $this, 'add_settings_field_callback' ],
 			'aspireupdate-settings',
 			'aspireupdate_settings_section',
 			[
-				'id'        => 'enable',
-				'type'      => 'checkbox',
-				'data'      => $options,
-				'label_for' => 'aspireupdate-settings-field-enable',
+				'id'    => 'enable',
+				'type'  => 'checkbox',
+				'data'  => $options,
+				'label' => esc_html__( 'Rewrite WordPress.org requests', 'aspireupdate' ),
 			]
 		);
 
@@ -456,12 +456,11 @@ class Admin_Settings {
 			'aspireupdate-settings',
 			'aspireupdate_settings_section',
 			[
-				'id'          => 'api_host',
-				'type'        => 'hosts',
-				'data'        => $options,
-				'description' => esc_html__( 'Your new API Host. Ensure that it starts with http:// or https://', 'aspireupdate' ),
-				'label_for'   => 'aspireupdate-settings-field-api_host',
-				'options'     => [
+				'id'        => 'api_host',
+				'type'      => 'hosts',
+				'data'      => $options,
+				'label_for' => 'aspireupdate-settings-field-api_host',
+				'options'   => [
 					[
 						'value'           => 'https://api.aspirecloud.net',
 						'label'           => sprintf(
@@ -501,25 +500,24 @@ class Admin_Settings {
 				'id'          => 'api_key',
 				'type'        => 'api-key',
 				'data'        => $options,
-				'description' => esc_html__( 'Provides an API key for repositories that may require authentication.', 'aspireupdate' ),
+				'description' => esc_html__( 'Some repositories may require an API key for authentication.', 'aspireupdate' ),
 				'label_for'   => 'aspireupdate-settings-field-api_key',
 			]
 		);
 
 		add_settings_field(
 			'compatibility',
-			esc_html__( 'Compatibility', 'aspireupdate' ),
+			'<span id="compatibility-field-group-label">' . esc_html__( 'Compatibility', 'aspireupdate' ) . '</span>',
 			[ $this, 'add_settings_field_callback' ],
 			'aspireupdate-settings',
 			'aspireupdate_settings_section',
 			[
-				'id'          => 'compatibility',
-				'type'        => 'checkbox-group',
-				'data'        => $options,
-				'options'     => [
+				'id'      => 'compatibility',
+				'type'    => 'checkbox-group',
+				'data'    => $options,
+				'options' => [
 					'skip_rewriting_on_existing_response' => esc_html__( 'Skip API rewriting if another plugin already appears to be rewriting API requests', 'aspireupdate' ),
 				],
-				'description' => esc_html__( 'Increase compatibility with other plugins.', 'aspireupdate' ),
 			]
 		);
 
@@ -536,51 +534,48 @@ class Admin_Settings {
 
 		add_settings_field(
 			'enable_debug',
-			esc_html__( 'Enable Debug Mode', 'aspireupdate' ),
+			esc_html__( 'Debug Mode', 'aspireupdate' ),
 			[ $this, 'add_settings_field_callback' ],
 			'aspireupdate-settings',
 			'aspireupdate_debug_settings_section',
 			[
-				'id'          => 'enable_debug',
-				'type'        => 'checkbox',
-				'data'        => $options,
-				'description' => esc_html__( 'Enables debug mode for the plugin.', 'aspireupdate' ),
-				'label_for'   => 'aspireupdate-settings-field-enable_debug',
+				'id'    => 'enable_debug',
+				'type'  => 'checkbox',
+				'data'  => $options,
+				'label' => esc_html__( 'Enable logging and other debugging functionality', 'aspireupdate' ),
 			]
 		);
 
 		add_settings_field(
 			'enable_debug_type',
-			esc_html__( 'Enable Debug Type', 'aspireupdate' ),
+			'<span id="enable_debug_type-field-group-label">' . esc_html__( 'Log Contents', 'aspireupdate' ) . '</span>',
 			[ $this, 'add_settings_field_callback' ],
 			'aspireupdate-settings',
 			'aspireupdate_debug_settings_section',
 			[
-				'id'          => 'enable_debug_type',
-				'type'        => 'checkbox-group',
-				'data'        => $options,
-				'options'     => [
-					'request'  => esc_html__( 'Request', 'aspireupdate' ),
-					'response' => esc_html__( 'Response', 'aspireupdate' ),
-					'string'   => esc_html__( 'String', 'aspireupdate' ),
+				'id'      => 'enable_debug_type',
+				'type'    => 'checkbox-group',
+				'data'    => $options,
+				'options' => [
+					'request'  => esc_html__( 'Include request arguments', 'aspireupdate' ),
+					'response' => esc_html__( 'Include response headers and body', 'aspireupdate' ),
+					'string'   => esc_html__( 'Include a simple description of each step in the rewriting process', 'aspireupdate' ),
 				],
-				'description' => esc_html__( 'Outputs the request URL and headers / response headers and body / string that is being rewritten.', 'aspireupdate' ),
 			]
 		);
 
 		add_settings_field(
 			'disable_ssl_verification',
-			esc_html__( 'Disable SSL Verification', 'aspireupdate' ),
+			esc_html__( 'SSL Verification', 'aspireupdate' ),
 			[ $this, 'add_settings_field_callback' ],
 			'aspireupdate-settings',
 			'aspireupdate_debug_settings_section',
 			[
-				'id'          => 'disable_ssl_verification',
-				'type'        => 'checkbox',
-				'data'        => $options,
-				'class'       => 'advanced-setting',
-				'description' => esc_html__( 'Disables the verification of SSL to allow local testing.', 'aspireupdate' ),
-				'label_for'   => 'aspireupdate-settings-field-disable_ssl_verification',
+				'id'    => 'disable_ssl_verification',
+				'type'  => 'checkbox',
+				'data'  => $options,
+				'class' => 'advanced-setting',
+				'label' => esc_html__( 'Disable SSL verification to allow for local testing', 'aspireupdate' ),
 			]
 		);
 	}
@@ -615,46 +610,92 @@ class Admin_Settings {
 		switch ( $type ) {
 			case 'text':
 				?>
-					<input type="text" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>" class="regular-text" aria-describedby="<?php echo esc_attr( $description_id ); ?>" />
+					<input
+						type="text"
+						id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>"
+						name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]"
+						value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>"
+						class="regular-text"
+						<?php if ( $description ) : ?>
+							aria-describedby="<?php echo esc_attr( $description_id ); ?>"
+						<?php endif; ?>
+					/>
+					<p class="description" id="<?php echo esc_attr( $description_id ); ?>"><?php echo esc_html( $description ); ?></p>
 					<?php
 				break;
 
 			case 'textarea':
 				?>
-					<textarea id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" rows="5" cols="50" aria-describedby="<?php echo esc_attr( $description_id ); ?>"><?php echo esc_textarea( $options[ $id ] ?? '' ); ?></textarea>
+					<textarea
+						id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>"
+						name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]"
+						rows="5"
+						cols="50"
+						<?php if ( $description ) : ?>
+							aria-describedby="<?php echo esc_attr( $description_id ); ?>"
+						<?php endif; ?>
+					>
+						<?php echo esc_textarea( $options[ $id ] ?? '' ); ?>
+					</textarea>
+					<p class="description" id="<?php echo esc_attr( $description_id ); ?>"><?php echo esc_html( $description ); ?></p>
 					<?php
 				break;
 
 			case 'checkbox':
 				?>
-					<input type="checkbox" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="1" <?php checked( 1, $options[ $id ] ?? 0 ); ?> aria-describedby="<?php echo esc_attr( $description_id ); ?>" />
+					<input
+						type="checkbox"
+						id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>"
+						name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]"
+						value="1"
+						<?php checked( 1, $options[ $id ] ?? 0 ); ?>
+					/>
+					<?php if ( isset( $args['label'] ) ) : ?>
+						<label for="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>">
+							<?php echo esc_html( $args['label'] ); ?>
+						</label>
+					<?php endif; ?>
 					<?php
 				break;
 
 			case 'checkbox-group':
-				foreach ( $group_options as $key => $label ) {
-					?>
+				?>
+				<div role="group" aria-labelledby="<?php echo esc_attr( $id ); ?>-field-group-label">
+				<?php foreach ( $group_options as $key => $label ) : ?>
+					<?php $item_id = "aspireupdate-settings-field-{$id}-{$key}"; ?>
 					<p>
-						<label>
-							<input type="checkbox" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>-<?php echo esc_attr( $key ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>][<?php echo esc_attr( $key ); ?>]" value="1" <?php checked( 1, $options[ $id ][ $key ] ?? 0 ); ?> /> <?php echo esc_html( $label ); ?>
-						</label>
+						<input type="checkbox" id="<?php echo esc_attr( $item_id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>][<?php echo esc_attr( $key ); ?>]" value="1" <?php checked( 1, $options[ $id ][ $key ] ?? 0 ); ?> />
+						<label for="<?php echo esc_attr( $item_id ); ?>"><?php echo esc_html( $label ); ?></label>
 					</p>
-					<?php
-				}
+				<?php endforeach; ?>
+				</div>
+				<?php
 				break;
 
 			case 'api-key':
 				?>
-					<input type="text" id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>" class="regular-text" aria-describedby="<?php echo esc_attr( $description_id ); ?>" />
+					<input
+						type="text"
+						id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>"
+						name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]"
+						value="<?php echo esc_attr( $options[ $id ] ?? '' ); ?>"
+						class="regular-text"
+						aria-describedby="aspireupdate-api-key-notice <?php echo $description ? esc_attr( $description_id ) : ''; ?>"
+					/>
 					<input type="button" id="aspireupdate-generate-api-key" value="Generate API Key" />
 					<label for="aspireupdate-generate-api-key"><?php esc_html_e( 'Generate API Key', 'aspireupdate' ); ?></label>
-					<p class="error"></p>
+					<p id="<?php echo esc_attr( $description_id ); ?>"><?php echo esc_html( $description ); ?></p>
+					<div id="aspireupdate-api-key-notice"></div>
 					<?php
 				break;
 
 			case 'hosts':
 				?>
-				<select id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]" class="regular-text" aria-describedby="<?php echo esc_attr( $description_id ); ?>">
+				<select
+					id="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>"
+					name="<?php echo esc_attr( $this->option_name ); ?>[<?php echo esc_attr( $id ); ?>]"
+					class="regular-text"
+				>
 					<?php
 					foreach ( $group_options as $group_option ) {
 						?>
@@ -671,6 +712,9 @@ class Admin_Settings {
 					?>
 				</select>
 				<p>
+					<label for="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>_other">
+						<?php esc_html_e( 'Enter a custom API host. Ensure that it starts with http:// or https://', 'aspireupdate' ); ?>
+					</label><br>
 					<input
 						type="url"
 						data-pattern="(https?)://.*"
@@ -683,7 +727,7 @@ class Admin_Settings {
 				<?php
 				break;
 		}
-		echo '<p class="description" id="' . esc_attr( $description_id ) . '">' . esc_html( $description ) . '</p>';
+
 		echo '</div>';
 	}
 

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -682,8 +682,10 @@ class Admin_Settings {
 						class="regular-text"
 						aria-describedby="aspireupdate-api-key-notice <?php echo $description ? esc_attr( $description_id ) : ''; ?>"
 					/>
-					<input type="button" id="aspireupdate-generate-api-key" value="Generate API Key" />
-					<label for="aspireupdate-generate-api-key"><?php esc_html_e( 'Generate API Key', 'aspireupdate' ); ?></label>
+					<button id="aspireupdate-generate-api-key" class="button button-secondary">
+						<span class="dashicons dashicons-admin-network" aria-hidden="true"></span>
+						<span><?php esc_html_e( 'Generate API Key', 'aspireupdate' ); ?></span>
+					</button>
 					<p id="<?php echo esc_attr( $description_id ); ?>"><?php echo esc_html( $description ); ?></p>
 					<div id="aspireupdate-api-key-notice"></div>
 					<?php

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -445,7 +445,7 @@ class Admin_Settings {
 				'id'    => 'enable',
 				'type'  => 'checkbox',
 				'data'  => $options,
-				'label' => esc_html__( 'Rewrite WordPress.org requests', 'aspireupdate' ),
+				'label' => esc_html__( 'Rewrite API requests', 'aspireupdate' ),
 			]
 		);
 

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -715,7 +715,7 @@ class Admin_Settings {
 				</select>
 				<p>
 					<label for="aspireupdate-settings-field-<?php echo esc_attr( $id ); ?>_other">
-						<?php esc_html_e( 'Enter a custom API host. Ensure that it starts with http:// or https://', 'aspireupdate' ); ?>
+						<?php esc_html_e( 'Enter a custom API host. Ensure that it starts with https://.', 'aspireupdate' ); ?>
 					</label><br>
 					<input
 						type="url"


### PR DESCRIPTION
# Pull Request

## What changed?

### Field Labels
Field labels have been changed to be more topical:

  - **Enable AspireUpdate API Rewrites** -> **API Rewriting**
  - **Enable Debug Mode** -> **Debug Mode**
  - **Enable Debug Type** -> **Log Contents**
  - **Disable SSL Verification** -> **SSL Verification**

Grouped fields, such as **Compatibility** and **Log Contents** have been wrapped in a container element which associates the group with the label.

### Field Descriptions
Field descriptions have either been modified, or removed.

- The descriptions for the following fields have been removed as checkbox labels are sufficient:
  - **API Rewriting**
  - **Compatibility**
  - **Debug Mode**
  - **Log Contents**
  - **SSL Verification**
- **API Host**: The description will now only display when "Other" has been selected.
  - The description has been changed from "Your new API Host. Ensure that it starts with http:// or https://" to "Enter a custom API host. Ensure that it starts with http:// or https://" to use active language.
- **API Key"**: Changed from "Provides an API key for repositories that may require authentication." to "Some repositories may require an API key for authentication.". However, it would be preferable to update this at some point to more active language that tells the user what they need to do. For example, "Check with your repository if you need an API key."

### Checkbox Labels
Checkbox labels have been added or changed, associated with their checkboxes and now use active language:

  - **API Rewriting**: "Rewrite WordPress.org requests"
  - **Debug Mode**:
    - "Enable logging and other debugging functionality".
  - **Log Contents**:
    - "Request" -> "Include request arguments".
    - "Response" -> "Include response headers and body".
    - "String" -> "Include a simple description of each step in the rewriting process".
  - **SSL Verification**:
    - "Disable SSL verification to allow for local testing".

### Notices
All notices now use the WordPress admin notice styling for consistency.

Some notices have been moved to be closer to the elements that triggered them:

- **API Key** notice - Moved to below the description.
- **Clear Log** notice - Moved to below the buttons at the bottom of the settings screen.
- **Read Log** notice - Moved to below the buttons at the bottom of the settings screen.

Additionally, all notices will be announced using `wp.a11y.speak()`.

### Additional

- An unused variable has been removed from `aspire-update.js`.
- A `console.log()` call has been removed from `aspire-update.js`.

### Before

![image](https://github.com/user-attachments/assets/69b85022-b5b8-42d9-8e7a-da0070c5474c)

### After

![image](https://github.com/user-attachments/assets/eb5cc318-5b2c-456a-8347-1abda9922627)

## Why did it change?

This is part of an overall effort to improve the accessibility of AspireUpdate's UI.

## Did you fix any specific issues?

See #379 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

