### PR TITLE
tweak: disable cache busting unless AP_DEBUG_BYPASS_CACHE is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The plugin can use the following configuration options in wp-config.php:
 | AP_DEBUG_TYPES                 |                                                                                  an array of debug modes |                     array('string', 'request', 'response') |
 | AP_DISABLE_SSL                 |                                                              Disabled SSL verification for local testing |                                                       true |
 | AP_REMOVE_UI                   | Disables plugin settings user interface and branding, defaults to config parameters set in wp-config.php |                                                      false |
+| AP_BYPASS_CACHE                |                                               Add a cache buster parameter to bypass cache for API calls |                                                      false |
 
 To set AP_COMPATIBILITY use an array to define the constant:
 

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -231,7 +231,7 @@ class API_Rewrite {
 
 					$parsed_args = $this->add_authorization_header( $parsed_args );
 					$parsed_args = $this->add_accept_json_header( $parsed_args, $url );
-					if ( defined( 'AP_DEBUG_BYPASS_CACHE' ) && AP_DEBUG_BYPASS_CACHE ) {
+					if ( defined( 'AP_BYPASS_CACHE' ) && AP_BYPASS_CACHE ) {
 						$url = $this->add_cache_buster( $url );
 					}
 					$protocol    = wp_parse_url( $url, PHP_URL_SCHEME );

--- a/includes/class-api-rewrite.php
+++ b/includes/class-api-rewrite.php
@@ -231,7 +231,9 @@ class API_Rewrite {
 
 					$parsed_args = $this->add_authorization_header( $parsed_args );
 					$parsed_args = $this->add_accept_json_header( $parsed_args, $url );
-					$url         = $this->add_cache_buster( $url );
+					if ( defined( 'AP_DEBUG_BYPASS_CACHE' ) && AP_DEBUG_BYPASS_CACHE ) {
+						$url = $this->add_cache_buster( $url );
+					}
 					$protocol    = wp_parse_url( $url, PHP_URL_SCHEME );
 					$updated_url = str_replace(
 						"{$protocol}://{$this->default_host}",

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -150,7 +150,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that cache buster is added to URL when AP_DEBUG_BYPASS_CACHE is true.
+	 * Test that cache buster is added to URL when AP_BYPASS_CACHE is true.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -158,7 +158,7 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 	 * @covers \AspireUpdate\API_Rewrite::add_cache_buster
 	 */
 	public function test_should_add_cache_buster_when_debug_bypass_cache_is_true() {
-		define( 'AP_DEBUG_BYPASS_CACHE', true );
+		define( 'AP_BYPASS_CACHE', true );
 
 		$actual = '';
 
@@ -179,13 +179,13 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that cache buster is _not_ added to URL when AP_DEBUG_BYPASS_CACHE is false.
+	 * Test that cache buster is _not_ added to URL when AP_BYPASS_CACHE is false.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function test_should_not_add_cache_buster_when_debug_bypass_cache_is_false() {
-		define( 'AP_DEBUG_BYPASS_CACHE', false );
+		define( 'AP_BYPASS_CACHE', false );
 
 		$actual = '';
 

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -148,7 +148,6 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, '' );
 		$api_rewrite->pre_http_request( false, [], 'https://' . $this->get_default_host() );
 
-		// $this->assertMatchesRegularExpression( '/my\.api\.org\?cache_buster=[0-9]+/', $actual );
 		$this->assertMatchesRegularExpression( '/my\.api\.org/', $actual );
 	}
 

--- a/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
+++ b/tests/phpunit/tests/API_Rewrite/APIRewrite_PreHttpRequestTest.php
@@ -148,7 +148,8 @@ class APIRewrite_PreHttpRequestTest extends WP_UnitTestCase {
 		$api_rewrite = new AspireUpdate\API_Rewrite( 'https://my.api.org', true, '' );
 		$api_rewrite->pre_http_request( false, [], 'https://' . $this->get_default_host() );
 
-		$this->assertMatchesRegularExpression( '/my\.api\.org\?cache_buster=[0-9]+/', $actual );
+		// $this->assertMatchesRegularExpression( '/my\.api\.org\?cache_buster=[0-9]+/', $actual );
+		$this->assertMatchesRegularExpression( '/my\.api\.org/', $actual );
 	}
 
 	/**


### PR DESCRIPTION
# Pull Request

## What changed?

This disables by default adding the cachebuster string to the query unless `AP_DEBUG_BYPASS_CACHE` is set and truthy.  There is no admin UI to enable it, and I don't anticipate ever needing one.

## Why did it change?

We want to control the query caching behavior on AC's end now.  POST requests aren't going to be cached anyway.

## Did you fix any specific issues?

none

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

