### PR TITLE
Workflows: Make E2E workflow manually triggered.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,12 +1,6 @@
 name: End-to-End Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
# Pull Request

## What changed?

- The End-to-End (E2E) tests workflow now only runs on `workflow_dispatch`; the manual trigger event.

## Why did it change?

- The workflow was running on every push, and was often needlessly using GitHub Actions minutes.

## Did you fix any specific issues?

Fixes #387

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

