### PR TITLE
Branding: Add an admin bar menu

### DIFF
--- a/assets/css/aspire-update.css
+++ b/assets/css/aspire-update.css
@@ -56,6 +56,19 @@
 	width: 20px;
 }
 
+#wp-admin-bar-aspireupdate-admin-bar-menu .aspireupdate-icon {
+	margin-inline-end: 0 !important;
+	padding: 6px 0.35em 0 !important;
+}
+
+#wp-admin-bar-aspireupdate-admin-bar-menu .aspireupdate-icon:before {
+	background: url(../images/aspirepress-logo-icon.svg) no-repeat center center / 20px 20px;
+	content: '';
+	width: 20px;
+	height: 20px;
+	display: block;
+}
+
 .button.button-clearlog {
 	border-color: #b32d2e;
 	color: #b32d2e;

--- a/includes/class-branding.php
+++ b/includes/class-branding.php
@@ -49,23 +49,12 @@ class Branding {
 	 * @param string $hook The page identifier.
 	 * @return void
 	 */
-	public function admin_enqueue_scripts( $hook ) {
+	public function admin_enqueue_scripts() {
 		if ( defined( 'AP_REMOVE_UI' ) && AP_REMOVE_UI ) {
 			return;
 		}
 
-		$allowed_screens = [
-			'update-core',
-			'plugins',
-			'plugin-install',
-			'themes',
-			'theme-install',
-		];
-
-		$screen = \WP_Screen::get( $hook );
-		if ( in_array( $screen->id, $allowed_screens, true ) ) {
-			wp_enqueue_style( 'aspire_update_settings_css', plugin_dir_url( __DIR__ ) . 'assets/css/aspire-update.css', [], AP_VERSION );
-		}
+		wp_enqueue_style( 'aspire_update_settings_css', plugin_dir_url( __DIR__ ) . 'assets/css/aspire-update.css', [], AP_VERSION );
 	}
 
 	/**

--- a/includes/class-branding.php
+++ b/includes/class-branding.php
@@ -27,6 +27,7 @@ class Branding {
 			$admin_notices_hook = is_multisite() ? 'network_admin_notices' : 'admin_notices';
 			add_action( $admin_notices_hook, [ $this, 'output_admin_notice' ] );
 			add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+			add_action( 'admin_bar_menu', [ $this, 'add_admin_bar_menu' ], 100 );
 		}
 	}
 
@@ -134,5 +135,67 @@ class Branding {
 		}
 
 		echo wp_kses_post( '<div class="notice aspireupdate-notice notice-info"><p>' . $message . '</p></div>' );
+	}
+
+	/**
+	 * Add a menu to the admin bar.
+	 *
+	 * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 * @return void
+	 */
+	public function add_admin_bar_menu( $wp_admin_bar ) {
+		if ( defined( 'AP_REMOVE_UI' ) && AP_REMOVE_UI ) {
+			return;
+		}
+
+		$admin_settings = Admin_Settings::get_instance();
+		$options_base   = is_multisite() ? 'settings.php' : 'options-general.php';
+		$settings_page  = network_admin_url( $options_base . '?page=aspireupdate-settings' );
+		$menu_id        = 'aspireupdate-admin-bar-menu';
+
+		$wp_admin_bar->add_menu(
+			[
+				'id'     => $menu_id,
+				'parent' => 'top-secondary',
+				'href'   => $settings_page,
+				'title'  => '<span class="ab-icon aspireupdate-icon"></span><span class="screen-reader-text">' . __( 'AspireUpdate', 'aspireupdate' ) . '</span>',
+			]
+		);
+
+		/* translators: 1: The API host's name. */
+		$status_message = __( 'API host: %1$s', 'aspireupdate' );
+		$api_host       = $admin_settings->get_setting( 'api_host' );
+		switch ( $api_host ) {
+			case 'https://api.aspirecloud.net':
+				$api_host_name = 'AspireCloud';
+				break;
+			case 'https://api.aspirecloud.io':
+				$api_host_name = 'AspireCloud Bleeding Edge';
+				break;
+			default:
+				$api_host_name = $api_host;
+				break;
+		}
+
+		$wp_admin_bar->add_menu(
+			[
+				'id'     => 'aspireupdate-admin-bar-menu-status',
+				'parent' => $menu_id,
+				'href'   => false,
+				'title'  => sprintf( $status_message, $api_host_name ),
+			]
+		);
+
+		$capability = is_multisite() ? 'manage_network' : 'manage_options';
+		if ( current_user_can( $capability ) ) {
+			$wp_admin_bar->add_menu(
+				[
+					'id'     => 'aspireupdate-admin-bar-menu-settings',
+					'parent' => $menu_id,
+					'href'   => $settings_page,
+					'title'  => __( 'AspireUpdate Settings', 'aspireupdate' ),
+				]
+			);
+		}
 	}
 }

--- a/tests/phpunit/tests/Branding/Branding_AddAdminBarMenuTest.php
+++ b/tests/phpunit/tests/Branding/Branding_AddAdminBarMenuTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Class Branding_AddAdminBarMenuTest
+ *
+ * @package AspireUpdate
+ */
+
+require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+
+/**
+ * Tests for Branding::add_admin_bar_menu()
+ *
+ * These tests cause constants to be defined.
+ * They must run in separate processes and must not preserve global state.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ *
+ * @covers \AspireUpdate\Branding::add_admin_bar_menu
+ */
+class Branding_AddAdminBarMenuTest extends WP_UnitTestCase {
+	/**
+	 * Test that the main admin bar menu is added.
+	 */
+	public function test_should_add_main_admin_bar_menu() {
+		$wp_admin_bar = new WP_Admin_Bar();
+		$branding     = new AspireUpdate\Branding();
+
+		$wp_admin_bar->initialize();
+		$branding->add_admin_bar_menu( $wp_admin_bar );
+
+		$actual = $wp_admin_bar->get_nodes();
+
+		$this->assertIsArray( $actual, 'There are no admin bar nodes.' );
+		$this->assertArrayHasKey(
+			'aspireupdate-admin-bar-menu',
+			$actual,
+			'The main admin bar menu is not present.'
+		);
+	}
+
+	/**
+	 * Test that the status menu item is added.
+	 */
+	public function test_should_add_status_menu_item() {
+		$wp_admin_bar = new WP_Admin_Bar();
+		$branding     = new AspireUpdate\Branding();
+
+		$wp_admin_bar->initialize();
+		$branding->add_admin_bar_menu( $wp_admin_bar );
+
+		$actual = $wp_admin_bar->get_nodes();
+
+		$this->assertIsArray( $actual, 'There are no admin bar nodes.' );
+
+		$this->assertArrayHasKey(
+			'aspireupdate-admin-bar-menu-status',
+			$actual,
+			'The status menu item is not present.'
+		);
+
+		$this->assertIsObject(
+			$actual['aspireupdate-admin-bar-menu-status'],
+			'The status menu item is not an object.'
+		);
+
+		$this->assertSame(
+			'aspireupdate-admin-bar-menu',
+			$actual['aspireupdate-admin-bar-menu-status']->parent,
+			'The status menu item is not a child of the main menu.'
+		);
+	}
+
+	/**
+	 * Test that the settings link is not added when the user lacks appropriate capabilities.
+	 */
+	public function test_should_not_add_settings_link_when_the_user_lacks_appropriate_capabilities() {
+		$wp_admin_bar = new WP_Admin_Bar();
+		$branding     = new AspireUpdate\Branding();
+
+		$wp_admin_bar->initialize();
+		$branding->add_admin_bar_menu( $wp_admin_bar );
+
+		$actual = $wp_admin_bar->get_nodes();
+
+		$this->assertIsArray( $actual, 'There are no admin bar nodes.' );
+		$this->assertArrayNotHasKey(
+			'aspireupdate-admin-bar-menu-settings',
+			$actual,
+			'The settings link is present.'
+		);
+	}
+
+	/**
+	 * Test that the settings link is added when the user has appropriate capabilities.
+	 */
+	public function test_should_add_settings_link_when_the_user_has_appropriate_capabilities() {
+		$user = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user );
+
+		$wp_admin_bar = new WP_Admin_Bar();
+		$branding     = new AspireUpdate\Branding();
+
+		$wp_admin_bar->initialize();
+		$branding->add_admin_bar_menu( $wp_admin_bar );
+
+		$actual = $wp_admin_bar->get_nodes();
+
+		$this->assertIsArray( $actual, 'There are no admin bar nodes.' );
+		$this->assertArrayHasKey(
+			'aspireupdate-admin-bar-menu-settings',
+			$actual,
+			'The settings link is not present.'
+		);
+	}
+
+	/**
+	 * Test that the menu is not added when AP_REMOVE_UI is set to true.
+	 */
+	public function test_should_not_enqueue_style_when_ap_remove_ui_is_true() {
+		// Prevent the menu from being added.
+		define( 'AP_REMOVE_UI', true );
+
+		$user = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user );
+
+		$wp_admin_bar = new WP_Admin_Bar();
+		$branding     = new AspireUpdate\Branding();
+
+		$wp_admin_bar->initialize();
+		$branding->add_admin_bar_menu( $wp_admin_bar );
+
+		$actual = $wp_admin_bar->get_nodes();
+
+		$this->assertIsNotArray( $actual, 'There are admin bar nodes.' );
+	}
+
+	/**
+	 * Test that the status menu item's content is correctly dependent on the api_host option.
+	 *
+	 * @dataProvider data_api_hosts_and_expected_names
+	 *
+	 * @param string $api_host The API host to test.
+	 * @param string $expected_name The expected name of the API host.
+	 */
+	public function test_should_set_status_menu_item_content_depending_on_the_api_host_option( $api_host, $expected_name ) {
+		define( 'AP_HOST', $api_host );
+
+		$wp_admin_bar = new WP_Admin_Bar();
+		$branding     = new AspireUpdate\Branding();
+
+		$wp_admin_bar->initialize();
+		$branding->add_admin_bar_menu( $wp_admin_bar );
+
+		$actual = $wp_admin_bar->get_nodes();
+
+		$this->assertIsArray( $actual, 'There are no admin bar nodes.' );
+
+		$this->assertArrayHasKey(
+			'aspireupdate-admin-bar-menu-status',
+			$actual,
+			'The status menu item is not present.'
+		);
+
+		$this->assertIsObject(
+			$actual['aspireupdate-admin-bar-menu-status'],
+			'The status menu item is not an object.'
+		);
+
+		$this->assertObjectHasProperty(
+			'title',
+			$actual['aspireupdate-admin-bar-menu-status'],
+			'The status menu item does not have a title property.'
+		);
+
+		$this->assertSame(
+			"API host: {$expected_name}",
+			$actual['aspireupdate-admin-bar-menu-status']->title,
+			'The status menu item title does not match the expected name.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_api_hosts_and_expected_names() {
+		return [
+			'AspireCloud'               => [
+				'api_host'      => 'https://api.aspirecloud.net',
+				'expected_name' => 'AspireCloud',
+			],
+			'AspireCloud Bleeding Edge' => [
+				'api_host'      => 'https://api.aspirecloud.io',
+				'expected_name' => 'AspireCloud Bleeding Edge',
+			],
+			'Other'                     => [
+				'api_host'      => 'https://my.api.org',
+				'expected_name' => 'https://my.api.org',
+			],
+		];
+	}
+}

--- a/tests/phpunit/tests/Branding/Branding_AddAdminBarMenuTest.php
+++ b/tests/phpunit/tests/Branding/Branding_AddAdminBarMenuTest.php
@@ -98,6 +98,10 @@ class Branding_AddAdminBarMenuTest extends WP_UnitTestCase {
 		$user = $this->factory->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $user );
 
+		if ( is_multisite() ) {
+			grant_super_admin( $user );
+		}
+
 		$wp_admin_bar = new WP_Admin_Bar();
 		$branding     = new AspireUpdate\Branding();
 

--- a/tests/phpunit/tests/Branding/Branding_AdminEnqueueScriptsTest.php
+++ b/tests/phpunit/tests/Branding/Branding_AdminEnqueueScriptsTest.php
@@ -23,74 +23,12 @@ class Branding_AdminEnqueueScriptsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the stylesheet is enqueued on certain screens.
-	 *
-	 * @dataProvider data_hooks
-	 *
-	 * @param string $hook The current screen's hook.
+	 * Test that the stylesheet is enqueued.
 	 */
-	public function test_should_enqueue_style_on_certain_screens( $hook ) {
+	public function test_should_enqueue_style() {
 		$branding = new AspireUpdate\Branding();
-		$branding->admin_enqueue_scripts( $hook );
+		$branding->admin_enqueue_scripts();
 		$this->assertTrue( wp_style_is( 'aspire_update_settings_css' ) );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array[]
-	 */
-	public function data_hooks() {
-		return self::text_array_to_dataprovider(
-			[
-				'update-core',
-				'plugins',
-				'plugin-install',
-				'themes',
-				'theme-install',
-			]
-		);
-	}
-
-	/**
-	 * Test that the stylesheet is not enqueued on adjacent screens.
-	 *
-	 * @dataProvider data_adjacent_screens
-	 *
-	 * @param string $hook The current screen's hook.
-	 */
-	public function test_should_not_enqueue_style_on_adjacent_screens( $hook ) {
-		if ( is_multisite() ) {
-			$hook .= '-network';
-		}
-
-		$branding = new AspireUpdate\Branding();
-		$branding->admin_enqueue_scripts( $hook );
-		$this->assertFalse( wp_style_is( 'aspire_update_settings_css' ) );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array[]
-	 */
-	public function data_adjacent_screens() {
-		return self::text_array_to_dataprovider(
-			[
-				'dashboard',
-				'nav-menus',
-				'plugin-editor',
-			]
-		);
-	}
-
-	/**
-	 * Test that the stylesheet is not enqueued when there is no screen.
-	 */
-	public function test_should_not_enqueue_style_when_there_is_no_screen() {
-		$branding = new AspireUpdate\Branding();
-		$branding->admin_enqueue_scripts( '' );
-		$this->assertFalse( wp_style_is( 'aspire_update_settings_css' ) );
 	}
 
 	/**


### PR DESCRIPTION
# Pull Request

## What changed?

- An admin bar menu has been added.
  - This displays the current API host value.
  - If the user has the appropriate capabilities, a link to the settings menu is included.
- If the `AP_REMOVE_UI` constant is set to `true`, the admin bar menu is not displayed.
- The stylesheet will be enqueued on all screens when in the administration area instead of just on certain screens.
  - Tests for `Branding::admin_enqueue_scripts()` have been updated to account for this.
- Includes tests for the new `Branding::add_admin_bar_menu()` method.

![image](https://github.com/user-attachments/assets/05ba00bb-1198-4233-90fe-1057d66b1c4a)

## Why did it change?

To add a more subtle way to indicate the API host status.

## Did you fix any specific issues?

See #379

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

