### PR TITLE
Hosts: Remove API key URLs for AspireCloud and AspireCloud Bleeding Edge.

### DIFF
--- a/hosts.json
+++ b/hosts.json
@@ -7,13 +7,11 @@
 	{
 		"url": "https://api.aspirecloud.net",
 		"label": "AspireCloud",
-		"api-key-url": "https://api.aspirecloud.net/v1/apitoken",
 		"require-api-key": false
 	},
 	{
 		"url": "https://api.aspirecloud.io",
 		"label": "AspireCloud Bleeding Edge",
-		"api-key-url": "https://api.aspirecloud.io/v1/apitoken",
 		"require-api-key": false
 	},
 	{


### PR DESCRIPTION
# Pull Request

## What changed?

- The API URLs for **AspireCloud** and **AspireCloud Bleeding Edge** have been removed.

### Before
#### AspireCloud
![image](https://github.com/user-attachments/assets/e4683f53-e923-46e7-958b-4f3367904de9)

#### AspireCloud Bleeding Edge
![image](https://github.com/user-attachments/assets/e6f80480-996b-417e-b004-edafa4b6c973)

### After
#### AspireCloud
![image](https://github.com/user-attachments/assets/80ff432e-3acb-4146-a435-95bd57b6a71e)

#### AspireCloud Bleeding Edge
![image](https://github.com/user-attachments/assets/9f0e6144-d691-4dc0-b71b-da12437ecd52)

## Why did it change?

The implementation of these endpoints for AspireCloud have been postponed, possibly indefinitely. This was causing an error on the settings page when attempting to generate an API key.

The feature remains available in the plugin, but is unused for now.

## Did you fix any specific issues?

Fixes #399

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

