### PR TITLE
Workflows: Change `playground-blueprint` to manual-only.

### DIFF
--- a/.github/workflows/playground-blueprint.yml
+++ b/.github/workflows/playground-blueprint.yml
@@ -1,11 +1,7 @@
 name: Update Playground Blueprint with Repository and Branch
 
 on:
-  push:
-    branches:
-      - playground-ready
-    tags:
-      - "**"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION


# Pull Request

## What changed?

- The `playground-blueprint` workflow has been changed to only trigger on `workflow_dispatch` (can only be run manually).

## Why did it change?

This workflow needs some more work as it's currently failing when pushing a tag. In the meantime, we'll manually update the version number in the `assets/playground/blueprint.json` file as part of our pre-release bump PRs.

## Did you fix any specific issues?

Fixes #406

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

